### PR TITLE
Regenerate controller code to fix missing aws_fieldexports.yaml entry

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,9 +1,9 @@
 ack_generate_info:
-  build_date: "2022-04-06T21:44:24Z"
-  build_hash: fc5620cf5fde243ee5124324d26bb7e952049bf2
-  go_version: go1.17.6
-  version: v0.18.3-dirty
-api_directory_checksum: f7e376daef64d0c299eb1338df3bd097290b334a
+  build_date: "2022-04-07T05:10:10Z"
+  build_hash: 9191f9d8912cf9c413cc45285cd0ea8bedd944f5
+  go_version: go1.18
+  version: v0.18.3-1-g9191f9d
+api_directory_checksum: 6972849b7a809751f78bbafa31eeb725ed5bc126
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.29
 generator_config_info:

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"os"
 
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
 	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
 	ackrtutil "github.com/aws-controllers-k8s/runtime/pkg/util"
@@ -31,7 +32,6 @@ import (
 
 	svctypes "github.com/aws-controllers-k8s/memorydb-controller/apis/v1alpha1"
 	svcresource "github.com/aws-controllers-k8s/memorydb-controller/pkg/resource"
-	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 
 	_ "github.com/aws-controllers-k8s/memorydb-controller/pkg/resource/acl"
 	_ "github.com/aws-controllers-k8s/memorydb-controller/pkg/resource/cluster"
@@ -39,6 +39,8 @@ import (
 	_ "github.com/aws-controllers-k8s/memorydb-controller/pkg/resource/snapshot"
 	_ "github.com/aws-controllers-k8s/memorydb-controller/pkg/resource/subnet_group"
 	_ "github.com/aws-controllers-k8s/memorydb-controller/pkg/resource/user"
+
+	"github.com/aws-controllers-k8s/memorydb-controller/pkg/version"
 )
 
 var (
@@ -104,7 +106,11 @@ func main() {
 	)
 	sc := ackrt.NewServiceController(
 		awsServiceAlias, awsServiceAPIGroup, awsServiceEndpointsID,
-		ackrt.VersionInfo{}, // TODO: populate version info
+		ackrt.VersionInfo{
+			version.GitCommit,
+			version.GitVersion,
+			version.BuildDate,
+		},
 	).WithLogger(
 		ctrlrt.Log,
 	).WithResourceManagerFactories(

--- a/config/crd/common/bases/services.k8s.aws_adoptedresources.yaml
+++ b/config/crd/common/bases/services.k8s.aws_adoptedresources.yaml
@@ -57,9 +57,8 @@ spec:
                     type: string
                 type: object
               kubernetes:
-                description: TargetKubernetesResource provides all the values necessary
-                  to identify a given ACK type and override any metadata values when
-                  creating a resource of that type.
+                description: ResourceWithMetadata provides the values necessary to
+                  create a Kubernetes resource and override any of its metadata values.
                 properties:
                   group:
                     type: string

--- a/config/crd/common/kustomization.yaml
+++ b/config/crd/common/kustomization.yaml
@@ -1,6 +1,7 @@
-# This file is NOT auto-generated
+# Code generated in runtime. DO NOT EDIT.
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - bases/services.k8s.aws_adoptedresources.yaml
+  - bases/services.k8s.aws_fieldexports.yaml

--- a/helm/crds/services.k8s.aws_adoptedresources.yaml
+++ b/helm/crds/services.k8s.aws_adoptedresources.yaml
@@ -57,9 +57,8 @@ spec:
                     type: string
                 type: object
               kubernetes:
-                description: TargetKubernetesResource provides all the values necessary
-                  to identify a given ACK type and override any metadata values when
-                  creating a resource of that type.
+                description: ResourceWithMetadata provides the values necessary to
+                  create a Kubernetes resource and override any of its metadata values.
                 properties:
                   group:
                     type: string


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Regenerated controller code to fix missing `aws_fieldexports.yaml` entry inside `config/crd/common/kustomization.yaml` file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
