### PR TITLE
Remove `UserNotFound` From ACL TerminalCondition

### DIFF
--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -108,7 +108,6 @@ resources:
       terminal_codes:
         - ACLAlreadyExistsFault
         - DefaultUserRequired
-        - UserNotFoundFault
         - DuplicateUserNameFault
         - ACLQuotaExceededFault
         - InvalidParameterValueException

--- a/generator.yaml
+++ b/generator.yaml
@@ -108,7 +108,6 @@ resources:
       terminal_codes:
         - ACLAlreadyExistsFault
         - DefaultUserRequired
-        - UserNotFoundFault
         - DuplicateUserNameFault
         - ACLQuotaExceededFault
         - InvalidParameterValueException

--- a/pkg/resource/acl/sdk.go
+++ b/pkg/resource/acl/sdk.go
@@ -639,7 +639,6 @@ func (rm *resourceManager) terminalAWSError(err error) bool {
 	switch awsErr.Code() {
 	case "ACLAlreadyExistsFault",
 		"DefaultUserRequired",
-		"UserNotFoundFault",
 		"DuplicateUserNameFault",
 		"ACLQuotaExceededFault",
 		"InvalidParameterValueException",

--- a/test/e2e/scenarios/ACL/acl_terminal_condition.yaml
+++ b/test/e2e/scenarios/ACL/acl_terminal_condition.yaml
@@ -35,7 +35,7 @@ steps:
       spec:
         name: acl$RANDOM_SUFFIX
         userNames:
-          - invaliduser
+          - "invalid username"
     wait:
       status:
         conditions:
@@ -67,7 +67,7 @@ steps:
         name: acl$RANDOM_SUFFIX
       spec:
         userNames:
-          - invalidusername
+          - "invalid username"
     wait:
       status:
         conditions:


### PR DESCRIPTION
User and ACL can be created out of order.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
