### PR TITLE
adding in missing kinds in the samples section of the olmconfig

### DIFF
--- a/olm/olmconfig.yaml
+++ b/olm/olmconfig.yaml
@@ -32,6 +32,16 @@ description: |-
 samples:
 - kind: Cluster
   spec: '{}'
+- kind: ParameterGroup
+  spec: '{}'
+- kind: User
+  spec: '{}'
+- kind: ACL
+  spec: '{}'
+- kind: Snapshot
+  spec: '{}'
+- kind: SubnetGroup
+  spec: '{}'
 maintainers:
 - name: "memorydb maintainer team"
   email: "ack-maintainers@amazon.com"


### PR DESCRIPTION
Issue #, if available:
N/A
Description of changes:
Adding in the missing kinds in the `samples` section, so that when the controller is released the `examples` section of the in the CSV has all the current kinds. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Adam D. Cornett <adc@redhat.com>