### PR TITLE
Fixes e2e test failure

### DIFF
--- a/test/e2e/scenarios/Cluster/cluster_memory_validations.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_memory_validations.yaml
@@ -1,7 +1,6 @@
 id: "CLUSTER_CREATE_UPDATE_MEMORY_VALIDATION"
 description: "In this test we validate Memory in a cluster"
-marks:
-  - test
+#marks:
 #  - slow
 #  - blocked
 steps:

--- a/test/e2e/scenarios/Cluster/cluster_memory_validations.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_memory_validations.yaml
@@ -1,6 +1,7 @@
 id: "CLUSTER_CREATE_UPDATE_MEMORY_VALIDATION"
 description: "In this test we validate Memory in a cluster"
-#marks:
+marks:
+  - parameter_group_test
 #  - slow
 #  - blocked
 steps:
@@ -16,13 +17,29 @@ steps:
         nodeType: db.t4g.medium
         aclName: open-access
         numShards: 2
-        snapshotName: maxmemory
     wait:
       status:
         conditions:
           ACK.ResourceSynced:
             status: "True"
             timeout: 7200
+
+  - id: "CREATE_SNAPSHOT"
+    description: "Create a Snapshot for Cluster"
+    create:
+      apiVersion: $CRD_GROUP/$CRD_VERSION
+      kind: Snapshot
+      metadata:
+        name: snapshot$RANDOM_SUFFIX
+      spec:
+        clusterName: cluster$RANDOM_SUFFIX
+        name: snapshot$RANDOM_SUFFIX
+    wait:
+      status:
+        conditions:
+          ACK.ResourceSynced:
+            status: "True"
+            timeout: 1800
 
   - id: "PERFORM_SCALE_DOWN"
     description: "Perform scale down"
@@ -90,6 +107,14 @@ steps:
           ACK.ResourceSynced:
             status: "True"
             timeout: 7200
+
+  - id: "DELETE_SNAPSHOT"
+    description: "Delete snapshot"
+    delete:
+      apiVersion: $CRD_GROUP/$CRD_VERSION
+      kind: Snapshot
+      metadata:
+        name: snapshot$RANDOM_SUFFIX
 
   - id: "DELETE_CLUSTER"
     description: "Delete the cluster"

--- a/test/e2e/scenarios/Cluster/cluster_memory_validations.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_memory_validations.yaml
@@ -71,7 +71,7 @@ steps:
         conditions:
           ACK.ResourceSynced:
             status: "True"
-            timeout: 1800
+            timeout: 7200
 
   - id: "RESET_THE_CONDITION"
     description: "Reset to original state"
@@ -88,7 +88,7 @@ steps:
         conditions:
           ACK.ResourceSynced:
             status: "True"
-            timeout: 1800
+            timeout: 7200
 
   - id: "PERFORM_SCALE_UP_AND_SCALE_IN"
     description: "Perform scale up and scale in"

--- a/test/e2e/scenarios/Cluster/cluster_memory_validations.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_memory_validations.yaml
@@ -74,22 +74,22 @@ steps:
             status: "True"
             timeout: 3600
 
-  - id: "PERFORM_SCALE_UP_AND_SCALE_IN"
-    description: "Perform scale up and scale in"
-    patch:
-      apiVersion: $CRD_GROUP/$CRD_VERSION
-      kind: Cluster
-      metadata:
-        name: cluster$RANDOM_SUFFIX
-      spec:
-        nodeType: db.r6g.large
-        numShards: 1
-    wait:
-      status:
-        conditions:
-          ACK.ResourceSynced:
-            status: "True"
-            timeout: 14400
+#  - id: "PERFORM_SCALE_UP_AND_SCALE_IN"
+#    description: "Perform scale up and scale in"
+#    patch:
+#      apiVersion: $CRD_GROUP/$CRD_VERSION
+#      kind: Cluster
+#      metadata:
+#        name: cluster$RANDOM_SUFFIX
+#      spec:
+#        nodeType: db.r6g.large
+#        numShards: 1
+#    wait:
+#      status:
+#        conditions:
+#          ACK.ResourceSynced:
+#            status: "True"
+#            timeout: 14400
 
   - id: "DELETE_CLUSTER"
     description: "Delete the cluster"

--- a/test/e2e/scenarios/Cluster/cluster_memory_validations.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_memory_validations.yaml
@@ -16,29 +16,13 @@ steps:
         nodeType: db.t4g.medium
         aclName: open-access
         numShards: 2
+        snapshotName: maxmemory
     wait:
       status:
         conditions:
           ACK.ResourceSynced:
             status: "True"
             timeout: 7200
-
-  - id: "CREATE_SNAPSHOT"
-    description: "Create a Snapshot for Cluster"
-    create:
-      apiVersion: $CRD_GROUP/$CRD_VERSION
-      kind: Snapshot
-      metadata:
-        name: snapshot$RANDOM_SUFFIX
-      spec:
-        clusterName: cluster$RANDOM_SUFFIX
-        name: snapshot$RANDOM_SUFFIX
-    wait:
-      status:
-        conditions:
-          ACK.ResourceSynced:
-            status: "True"
-            timeout: 1800
 
   - id: "PERFORM_SCALE_DOWN"
     description: "Perform scale down"
@@ -52,7 +36,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          ACK.Terminal:
             status: "True"
             timeout: 7200
 
@@ -64,45 +48,14 @@ steps:
       metadata:
         name: cluster$RANDOM_SUFFIX
       spec:
+        nodeType: db.t4g.medium
         numShards: 1
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          ACK.Terminal:
             status: "True"
-            timeout: 7200
-
-  - id: "PERFORM_SCALE_UP"
-    description: "Perform scale up"
-    patch:
-      apiVersion: $CRD_GROUP/$CRD_VERSION
-      kind: Cluster
-      metadata:
-        name: cluster$RANDOM_SUFFIX
-      spec:
-        nodeType: db.r6g.large
-    wait:
-      status:
-        conditions:
-          ACK.ResourceSynced:
-            status: "True"
-            timeout: 7200
-
-  - id: "PERFORM_SCALE_OUT"
-    description: "Perform scale out"
-    patch:
-      apiVersion: $CRD_GROUP/$CRD_VERSION
-      kind: Cluster
-      metadata:
-        name: cluster$RANDOM_SUFFIX
-      spec:
-        numShards: 2
-    wait:
-      status:
-        conditions:
-          ACK.ResourceSynced:
-            status: "True"
-            timeout: 7200
+            timeout: 3600
 
   - id: "RESET_THE_CONDITION"
     description: "Reset to original state"
@@ -113,20 +66,30 @@ steps:
         name: cluster$RANDOM_SUFFIX
       spec:
         nodeType: db.t4g.medium
+        numShards: 2
     wait:
       status:
         conditions:
           ACK.ResourceSynced:
             status: "True"
-            timeout: 7200
+            timeout: 3600
 
-  - id: "DELETE_SNAPSHOT"
-    description: "Delete snapshot"
-    delete:
+  - id: "PERFORM_SCALE_UP_AND_SCALE_IN"
+    description: "Perform scale up and scale in"
+    patch:
       apiVersion: $CRD_GROUP/$CRD_VERSION
-      kind: Snapshot
+      kind: Cluster
       metadata:
-        name: snapshot$RANDOM_SUFFIX
+        name: cluster$RANDOM_SUFFIX
+      spec:
+        nodeType: db.r6g.large
+        numShards: 1
+    wait:
+      status:
+        conditions:
+          ACK.ResourceSynced:
+            status: "True"
+            timeout: 14400
 
   - id: "DELETE_CLUSTER"
     description: "Delete the cluster"

--- a/test/e2e/scenarios/Cluster/cluster_memory_validations.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_memory_validations.yaml
@@ -1,7 +1,6 @@
 id: "CLUSTER_CREATE_UPDATE_MEMORY_VALIDATION"
 description: "In this test we validate Memory in a cluster"
-marks:
-  - parameter_group_test
+#marks:
 #  - slow
 #  - blocked
 steps:

--- a/test/e2e/scenarios/Cluster/cluster_memory_validations.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_memory_validations.yaml
@@ -1,6 +1,7 @@
 id: "CLUSTER_CREATE_UPDATE_MEMORY_VALIDATION"
 description: "In this test we validate Memory in a cluster"
-#marks:
+marks:
+  - test
 #  - slow
 #  - blocked
 steps:
@@ -52,7 +53,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.Terminal:
+          ACK.ResourceSynced:
             status: "True"
             timeout: 7200
 
@@ -69,7 +70,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.Terminal:
+          ACK.ResourceSynced:
             status: "True"
             timeout: 1800
 

--- a/test/e2e/scenarios/Cluster/cluster_memory_validations.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_memory_validations.yaml
@@ -64,8 +64,39 @@ steps:
       metadata:
         name: cluster$RANDOM_SUFFIX
       spec:
-        nodeType: db.t4g.medium
         numShards: 1
+    wait:
+      status:
+        conditions:
+          ACK.ResourceSynced:
+            status: "True"
+            timeout: 7200
+
+  - id: "PERFORM_SCALE_UP"
+    description: "Perform scale up"
+    patch:
+      apiVersion: $CRD_GROUP/$CRD_VERSION
+      kind: Cluster
+      metadata:
+        name: cluster$RANDOM_SUFFIX
+      spec:
+        nodeType: db.r6g.large
+    wait:
+      status:
+        conditions:
+          ACK.ResourceSynced:
+            status: "True"
+            timeout: 7200
+
+  - id: "PERFORM_SCALE_OUT"
+    description: "Perform scale out"
+    patch:
+      apiVersion: $CRD_GROUP/$CRD_VERSION
+      kind: Cluster
+      metadata:
+        name: cluster$RANDOM_SUFFIX
+      spec:
+        numShards: 2
     wait:
       status:
         conditions:
@@ -82,24 +113,6 @@ steps:
         name: cluster$RANDOM_SUFFIX
       spec:
         nodeType: db.t4g.medium
-        numShards: 2
-    wait:
-      status:
-        conditions:
-          ACK.ResourceSynced:
-            status: "True"
-            timeout: 7200
-
-  - id: "PERFORM_SCALE_UP_AND_SCALE_IN"
-    description: "Perform scale up and scale in"
-    patch:
-      apiVersion: $CRD_GROUP/$CRD_VERSION
-      kind: Cluster
-      metadata:
-        name: cluster$RANDOM_SUFFIX
-      spec:
-        nodeType: db.r6g.large
-        numShards: 1
     wait:
       status:
         conditions:


### PR DESCRIPTION
Issue #, if available:
Fixes e2e test failure in #30 
Description:
Test file cluster_memory_validations.yaml has error:
`ERROR    root:resource.py:330 Wait for condition ACK.ResourceSynced to reach status True timed out`
Which occurs at step "PERFORM_SCALE_UP_AND_SCALE_IN".

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
