### PR TITLE
Fixes timeout issue.

### DIFF
--- a/test/e2e/scenarios/Cluster/cluster_memory_validations.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_memory_validations.yaml
@@ -22,7 +22,7 @@ steps:
         conditions:
           ACK.ResourceSynced:
             status: "True"
-            timeout: 7200
+            timeout: 14400
 
   - id: "PERFORM_SCALE_DOWN"
     description: "Perform scale down"


### PR DESCRIPTION
Description of changes:
Current waiting time in test file isn't enough for creating cluster. e2e test fails sometimes because cluster is still creating. Adds more wait time for creating cluster step.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
