### PR TITLE
Tag and Untag API for cluster.

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-12-14T00:10:49Z"
+  build_date: "2022-12-22T20:12:01Z"
   build_hash: 16f0e201b37a06b535370cc69e11adb934a22d33
   go_version: go1.19
   version: v0.20.1-18-g16f0e20

--- a/pkg/resource/cluster/hooks.go
+++ b/pkg/resource/cluster/hooks.go
@@ -17,15 +17,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
-	"strconv"
+	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
+	ackutil "github.com/aws-controllers-k8s/runtime/pkg/util"
 
 	svcapitypes "github.com/aws-controllers-k8s/memorydb-controller/apis/v1alpha1"
 	svcsdk "github.com/aws/aws-sdk-go/service/memorydb"
-
-	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
 )
 
 var (
@@ -261,4 +262,131 @@ func (rm *resourceManager) newMemoryDBClusterUploadPayload(
 	}
 
 	return res
+}
+
+// getTags gets tags from given ParameterGroup.
+func (rm *resourceManager) getTags(
+	ctx context.Context,
+	resourceARN string,
+) ([]*svcapitypes.Tag, error) {
+	resp, err := rm.sdkapi.ListTagsWithContext(
+		ctx,
+		&svcsdk.ListTagsInput{
+			ResourceArn: &resourceARN,
+		},
+	)
+	rm.metrics.RecordAPICall("GET", "ListTags", err)
+	if err != nil {
+		return nil, err
+	}
+	tags := resourceTagsFromSDKTags(resp.TagList)
+	return tags, nil
+}
+
+// updateTags updates tags of given ParameterGroup to desired tags.
+func (rm *resourceManager) updateTags(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.updateTags")
+	defer func(err error) { exit(err) }(err)
+
+	arn := (*string)(latest.ko.Status.ACKResourceMetadata.ARN)
+
+	toAdd, toDelete := computeTagsDelta(
+		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
+	)
+
+	if len(toDelete) > 0 {
+		rlog.Debug("removing tags from cluster", "tags", toDelete)
+		_, err = rm.sdkapi.UntagResourceWithContext(
+			ctx,
+			&svcsdk.UntagResourceInput{
+				ResourceArn: arn,
+				TagKeys:     toDelete,
+			},
+		)
+		rm.metrics.RecordAPICall("UPDATE", "UntagResource", err)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(toAdd) > 0 {
+		rlog.Debug("adding tags to cluster", "tags", toAdd)
+		_, err = rm.sdkapi.TagResourceWithContext(
+			ctx,
+			&svcsdk.TagResourceInput{
+				ResourceArn: arn,
+				Tags:        sdkTagsFromResourceTags(toAdd),
+			},
+		)
+		rm.metrics.RecordAPICall("UPDATE", "TagResource", err)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func computeTagsDelta(
+	desired []*svcapitypes.Tag,
+	latest []*svcapitypes.Tag,
+) (addedOrUpdated []*svcapitypes.Tag, removed []*string) {
+	var visitedIndexes []string
+
+	for _, latestElement := range latest {
+		visitedIndexes = append(visitedIndexes, *latestElement.Key)
+		for _, desiredElement := range desired {
+			if equalStrings(latestElement.Key, desiredElement.Key) {
+				if !equalStrings(latestElement.Value, desiredElement.Value) {
+					addedOrUpdated = append(addedOrUpdated, desiredElement)
+				}
+				continue
+			}
+		}
+		removed = append(removed, latestElement.Key)
+	}
+	for _, desiredElement := range desired {
+		if !ackutil.InStrings(*desiredElement.Key, visitedIndexes) {
+			addedOrUpdated = append(addedOrUpdated, desiredElement)
+		}
+	}
+	return addedOrUpdated, removed
+}
+
+func sdkTagsFromResourceTags(
+	rTags []*svcapitypes.Tag,
+) []*svcsdk.Tag {
+	tags := make([]*svcsdk.Tag, len(rTags))
+	for i := range rTags {
+		tags[i] = &svcsdk.Tag{
+			Key:   rTags[i].Key,
+			Value: rTags[i].Value,
+		}
+	}
+	return tags
+}
+
+func resourceTagsFromSDKTags(
+	sdkTags []*svcsdk.Tag,
+) []*svcapitypes.Tag {
+	tags := make([]*svcapitypes.Tag, len(sdkTags))
+	for i := range sdkTags {
+		tags[i] = &svcapitypes.Tag{
+			Key:   sdkTags[i].Key,
+			Value: sdkTags[i].Value,
+		}
+	}
+	return tags
+}
+
+func equalStrings(a, b *string) bool {
+	if a == nil {
+		return b == nil || *b == ""
+	}
+	return (*a == "" && b == nil) || *a == *b
 }

--- a/templates/hooks/cluster/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/cluster/sdk_read_many_post_set_output.go.tpl
@@ -28,3 +28,10 @@
 	if respErr != nil {
 		return nil, respErr
 	}
+
+	resourceARN := (*string)(ko.Status.ACKResourceMetadata.ARN)
+    tags, err := rm.getTags(ctx, *resourceARN)
+    if err != nil {
+        return nil, err
+    }
+    ko.Spec.Tags = tags

--- a/templates/hooks/cluster/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/cluster/sdk_update_pre_build_request.go.tpl
@@ -3,3 +3,14 @@
 	if err != nil || res!= nil{
 		return res, err
 	}
+
+	if delta.DifferentAt("Spec.Tags") {
+        err = rm.updateTags(ctx, desired, latest)
+        if err != nil {
+            return nil, err
+        }
+    }
+
+    if !delta.DifferentExcept("Spec.Tags") {
+    	return desired, nil
+    }

--- a/test/e2e/scenarios/Cluster/cluster_update_with_tags.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_update_with_tags.yaml
@@ -1,0 +1,84 @@
+id: "CLUSTER_UPDATE_WITH_TAGS"
+description: "In this test we create cluster and update cluster with tags"
+#marks:
+#  - slow
+#  - blocked
+steps:
+  - id: "CLUSTER_INITIAL_CREATE"
+    description: "Create Cluster with no tags"
+    create:
+      apiVersion: $CRD_GROUP/$CRD_VERSION
+      kind: Cluster
+      metadata:
+        name: cluster$RANDOM_SUFFIX
+      spec:
+        name: cluster$RANDOM_SUFFIX
+        nodeType: db.t4g.small
+        aclName: open-access
+        numShards: 1
+    wait:
+      status:
+        conditions:
+          ACK.ResourceSynced:
+            status: "True"
+            timeout: 7200
+  - id: "CLUSTER_ADD_TAGS"
+    description: "Add tags in Cluster"
+    patch:
+      apiVersion: $CRD_GROUP/$CRD_VERSION
+      kind: Cluster
+      metadata:
+        name: cluster$RANDOM_SUFFIX
+      spec:
+        tags:
+          - key: "test_key_1"
+            value: "test_value_1"
+          - key: "test_key_2"
+          - key:
+    wait:
+      status:
+        conditions:
+          ACK.ResourceSynced:
+            status: "True"
+            timeout: 100
+  - id: "CLUSTER_DELETE_TAGS"
+    description: "Delete tags in Cluster"
+    patch:
+      apiVersion: $CRD_GROUP/$CRD_VERSION
+      kind: Cluster
+      metadata:
+        name: cluster$RANDOM_SUFFIX
+      spec:
+        tags:
+          - key: "test_key_1"
+            value: "test_value_1"
+    wait:
+      status:
+        conditions:
+          ACK.ResourceSynced:
+            status: "True"
+            timeout: 100
+  - id: "Cluster_ADD_AND_DELETE_TAGS"
+    description: "Add some tags and delete some tags in Cluster"
+    patch:
+      apiVersion: $CRD_GROUP/$CRD_VERSION
+      kind: Cluster
+      metadata:
+        name: cluster$RANDOM_SUFFIX
+      spec:
+        tags:
+          - key: "test_key_2"
+            value: "test_value_2"
+    wait:
+      status:
+        conditions:
+          ACK.ResourceSynced:
+            status: "True"
+            timeout: 100
+  - id: "DELETE_CLUSTER"
+    description: "Delete the cluster"
+    delete:
+      apiVersion: $CRD_GROUP/$CRD_VERSION
+      kind: Cluster
+      metadata:
+        name: cluster$RANDOM_SUFFIX


### PR DESCRIPTION
Issue #, if available:
ACK MemoryDB controller doesn't provide tags update after creation of cluster.

Description of changes:
Add functions so that customers can update tags of cluster after creation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
