### PR TITLE
Support Describe Events

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2023-03-03T20:58:18Z"
+  build_date: "2023-03-07T06:28:37Z"
   build_hash: d0f3d78cbea8061f822cbceac3786128f091efe6
   go_version: go1.19
   version: v0.24.2
-api_directory_checksum: 321c79032b9f73aba90926b35167e224f577ecd6
+api_directory_checksum: 863961569e4c45d940e482713a85bac302b37d66
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: c1d34ab8fe5fc4fa9f0fcc7098afa04a4701e675
+  file_checksum: c6f69226d010aa15f4ed3ac9f2b619bbdcdf798b
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/acl.go
+++ b/apis/v1alpha1/acl.go
@@ -54,6 +54,10 @@ type ACLStatus struct {
 	// A list of clusters associated with the ACL.
 	// +kubebuilder:validation:Optional
 	Clusters []*string `json:"clusters,omitempty"`
+	// A list of events. Each element in the list contains detailed information
+	// about one event.
+	// +kubebuilder:validation:Optional
+	Events []*Event `json:"events,omitempty"`
 	// The minimum engine version supported for the ACL
 	// +kubebuilder:validation:Optional
 	MinimumEngineVersion *string `json:"minimumEngineVersion,omitempty"`

--- a/apis/v1alpha1/cluster.go
+++ b/apis/v1alpha1/cluster.go
@@ -124,6 +124,10 @@ type ClusterStatus struct {
 	// The Redis engine patch version used by the cluster
 	// +kubebuilder:validation:Optional
 	EnginePatchVersion *string `json:"enginePatchVersion,omitempty"`
+	// A list of events. Each element in the list contains detailed information
+	// about one event.
+	// +kubebuilder:validation:Optional
+	Events []*Event `json:"events,omitempty"`
 	// The number of shards in the cluster
 	// +kubebuilder:validation:Optional
 	NumberOfShards *int64 `json:"numberOfShards,omitempty"`

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -42,6 +42,11 @@ resources:
         from:
           operation: ListAllowedNodeTypeUpdates
           path: ScaleDownNodeTypes
+      Events:
+        is_read_only: true
+        from:
+          operation: DescribeEvents
+          path: Events
       ParameterGroupName:
         references:
           resource: ParameterGroup
@@ -138,6 +143,11 @@ resources:
         - InvalidParameterValueException
         - InvalidParameterCombinationException
     fields:
+      Events:
+        is_read_only: true
+        from:
+          operation: DescribeEvents
+          path: Events
       UserNames:
         references:
           resource: User
@@ -185,6 +195,11 @@ resources:
         is_secret: true
         compare:
           is_ignored: true
+      Events:
+        is_read_only: true
+        from:
+          operation: DescribeEvents
+          path: Events
     hooks:
       sdk_create_post_set_output:
         code: "rm.setAnnotationsFields(desired, ko)"

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -151,6 +151,7 @@ type Event struct {
 	Date       *metav1.Time `json:"date,omitempty"`
 	Message    *string      `json:"message,omitempty"`
 	SourceName *string      `json:"sourceName,omitempty"`
+	SourceType *string      `json:"sourceType,omitempty"`
 }
 
 // Used to streamline results of a search based on the property being filtered.

--- a/apis/v1alpha1/user.go
+++ b/apis/v1alpha1/user.go
@@ -63,6 +63,10 @@ type UserStatus struct {
 	// Denotes whether the user requires a password to authenticate.
 	// +kubebuilder:validation:Optional
 	Authentication *Authentication `json:"authentication,omitempty"`
+	// A list of events. Each element in the list contains detailed information
+	// about one event.
+	// +kubebuilder:validation:Optional
+	Events []*Event `json:"events,omitempty"`
 	// The minimum engine version supported for the user
 	// +kubebuilder:validation:Optional
 	MinimumEngineVersion *string `json:"minimumEngineVersion,omitempty"`

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -204,6 +204,17 @@ func (in *ACLStatus) DeepCopyInto(out *ACLStatus) {
 			}
 		}
 	}
+	if in.Events != nil {
+		in, out := &in.Events, &out.Events
+		*out = make([]*Event, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(Event)
+				(*in).DeepCopyInto(*out)
+			}
+		}
+	}
 	if in.MinimumEngineVersion != nil {
 		in, out := &in.MinimumEngineVersion, &out.MinimumEngineVersion
 		*out = new(string)
@@ -805,6 +816,17 @@ func (in *ClusterStatus) DeepCopyInto(out *ClusterStatus) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Events != nil {
+		in, out := &in.Events, &out.Events
+		*out = make([]*Event, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(Event)
+				(*in).DeepCopyInto(*out)
+			}
+		}
+	}
 	if in.NumberOfShards != nil {
 		in, out := &in.NumberOfShards, &out.NumberOfShards
 		*out = new(int64)
@@ -1085,6 +1107,11 @@ func (in *Event) DeepCopyInto(out *Event) {
 	}
 	if in.SourceName != nil {
 		in, out := &in.SourceName, &out.SourceName
+		*out = new(string)
+		**out = **in
+	}
+	if in.SourceType != nil {
+		in, out := &in.SourceType, &out.SourceType
 		*out = new(string)
 		**out = **in
 	}
@@ -2361,6 +2388,17 @@ func (in *UserStatus) DeepCopyInto(out *UserStatus) {
 		in, out := &in.Authentication, &out.Authentication
 		*out = new(Authentication)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.Events != nil {
+		in, out := &in.Events, &out.Events
+		*out = make([]*Event, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(Event)
+				(*in).DeepCopyInto(*out)
+			}
+		}
 	}
 	if in.MinimumEngineVersion != nil {
 		in, out := &in.MinimumEngineVersion, &out.MinimumEngineVersion

--- a/config/crd/bases/memorydb.services.k8s.aws_acls.yaml
+++ b/config/crd/bases/memorydb.services.k8s.aws_acls.yaml
@@ -152,6 +152,25 @@ spec:
                   - type
                   type: object
                 type: array
+              events:
+                description: A list of events. Each element in the list contains detailed
+                  information about one event.
+                items:
+                  description: Represents a single occurrence of something interesting
+                    within the system. Some examples of events are creating a cluster
+                    or adding or removing a node.
+                  properties:
+                    date:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    sourceName:
+                      type: string
+                    sourceType:
+                      type: string
+                  type: object
+                type: array
               minimumEngineVersion:
                 description: The minimum engine version supported for the ACL
                 type: string

--- a/config/crd/bases/memorydb.services.k8s.aws_clusters.yaml
+++ b/config/crd/bases/memorydb.services.k8s.aws_clusters.yaml
@@ -322,6 +322,25 @@ spec:
               enginePatchVersion:
                 description: The Redis engine patch version used by the cluster
                 type: string
+              events:
+                description: A list of events. Each element in the list contains detailed
+                  information about one event.
+                items:
+                  description: Represents a single occurrence of something interesting
+                    within the system. Some examples of events are creating a cluster
+                    or adding or removing a node.
+                  properties:
+                    date:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    sourceName:
+                      type: string
+                    sourceType:
+                      type: string
+                  type: object
+                type: array
               numberOfShards:
                 description: The number of shards in the cluster
                 format: int64

--- a/config/crd/bases/memorydb.services.k8s.aws_users.yaml
+++ b/config/crd/bases/memorydb.services.k8s.aws_users.yaml
@@ -176,6 +176,25 @@ spec:
                   - type
                   type: object
                 type: array
+              events:
+                description: A list of events. Each element in the list contains detailed
+                  information about one event.
+                items:
+                  description: Represents a single occurrence of something interesting
+                    within the system. Some examples of events are creating a cluster
+                    or adding or removing a node.
+                  properties:
+                    date:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    sourceName:
+                      type: string
+                    sourceType:
+                      type: string
+                  type: object
+                type: array
               minimumEngineVersion:
                 description: The minimum engine version supported for the user
                 type: string

--- a/generator.yaml
+++ b/generator.yaml
@@ -42,6 +42,11 @@ resources:
         from:
           operation: ListAllowedNodeTypeUpdates
           path: ScaleDownNodeTypes
+      Events:
+        is_read_only: true
+        from:
+          operation: DescribeEvents
+          path: Events
       ParameterGroupName:
         references:
           resource: ParameterGroup
@@ -138,6 +143,11 @@ resources:
         - InvalidParameterValueException
         - InvalidParameterCombinationException
     fields:
+      Events:
+        is_read_only: true
+        from:
+          operation: DescribeEvents
+          path: Events
       UserNames:
         references:
           resource: User
@@ -185,6 +195,11 @@ resources:
         is_secret: true
         compare:
           is_ignored: true
+      Events:
+        is_read_only: true
+        from:
+          operation: DescribeEvents
+          path: Events
     hooks:
       sdk_create_post_set_output:
         code: "rm.setAnnotationsFields(desired, ko)"

--- a/helm/crds/memorydb.services.k8s.aws_acls.yaml
+++ b/helm/crds/memorydb.services.k8s.aws_acls.yaml
@@ -152,6 +152,25 @@ spec:
                   - type
                   type: object
                 type: array
+              events:
+                description: A list of events. Each element in the list contains detailed
+                  information about one event.
+                items:
+                  description: Represents a single occurrence of something interesting
+                    within the system. Some examples of events are creating a cluster
+                    or adding or removing a node.
+                  properties:
+                    date:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    sourceName:
+                      type: string
+                    sourceType:
+                      type: string
+                  type: object
+                type: array
               minimumEngineVersion:
                 description: The minimum engine version supported for the ACL
                 type: string

--- a/helm/crds/memorydb.services.k8s.aws_clusters.yaml
+++ b/helm/crds/memorydb.services.k8s.aws_clusters.yaml
@@ -322,6 +322,25 @@ spec:
               enginePatchVersion:
                 description: The Redis engine patch version used by the cluster
                 type: string
+              events:
+                description: A list of events. Each element in the list contains detailed
+                  information about one event.
+                items:
+                  description: Represents a single occurrence of something interesting
+                    within the system. Some examples of events are creating a cluster
+                    or adding or removing a node.
+                  properties:
+                    date:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    sourceName:
+                      type: string
+                    sourceType:
+                      type: string
+                  type: object
+                type: array
               numberOfShards:
                 description: The number of shards in the cluster
                 format: int64

--- a/helm/crds/memorydb.services.k8s.aws_users.yaml
+++ b/helm/crds/memorydb.services.k8s.aws_users.yaml
@@ -176,6 +176,25 @@ spec:
                   - type
                   type: object
                 type: array
+              events:
+                description: A list of events. Each element in the list contains detailed
+                  information about one event.
+                items:
+                  description: Represents a single occurrence of something interesting
+                    within the system. Some examples of events are creating a cluster
+                    or adding or removing a node.
+                  properties:
+                    date:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    sourceName:
+                      type: string
+                    sourceType:
+                      type: string
+                  type: object
+                type: array
               minimumEngineVersion:
                 description: The minimum engine version supported for the user
                 type: string

--- a/pkg/resource/acl/sdk.go
+++ b/pkg/resource/acl/sdk.go
@@ -164,6 +164,11 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
+	ko.Status.Events, err = rm.getEvents(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
 	if rm.isACLActive(&resource{ko}) {
 		resourceARN := (*string)(ko.Status.ACKResourceMetadata.ARN)
 		tags, err := rm.getTags(ctx, *resourceARN)

--- a/pkg/resource/cluster/sdk.go
+++ b/pkg/resource/cluster/sdk.go
@@ -352,6 +352,11 @@ func (rm *resourceManager) sdkFind(
 		return nil, respErr
 	}
 
+	ko.Status.Events, err = rm.getEvents(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
 	if rm.isClusterAvailable(&resource{ko}) {
 		resourceARN := (*string)(ko.Status.ACKResourceMetadata.ARN)
 		tags, err := rm.getTags(ctx, *resourceARN)

--- a/pkg/resource/snapshot/hooks.go
+++ b/pkg/resource/snapshot/hooks.go
@@ -259,7 +259,7 @@ func (rm *resourceManager) isSnapshotAvailable(
 	return latestStatus != nil && *latestStatus == resourceStatusAvailable
 }
 
-// getTags gets tags from given ParameterGroup.
+// getTags gets tags from given Snapshot.
 func (rm *resourceManager) getTags(
 	ctx context.Context,
 	resourceARN string,
@@ -295,7 +295,7 @@ func (rm *resourceManager) customUpdate(
 	return desired, nil
 }
 
-// updateTags updates tags of given ParameterGroup to desired tags.
+// updateTags updates tags of given Snapshot to desired tags.
 func (rm *resourceManager) updateTags(
 	ctx context.Context,
 	desired *resource,

--- a/pkg/resource/subnet_group/hooks.go
+++ b/pkg/resource/subnet_group/hooks.go
@@ -23,7 +23,7 @@ import (
 	svcapitypes "github.com/aws-controllers-k8s/memorydb-controller/apis/v1alpha1"
 )
 
-// getTags gets tags from given ParameterGroup.
+// getTags gets tags from given SubnetGroup.
 func (rm *resourceManager) getTags(
 	ctx context.Context,
 	resourceARN string,
@@ -42,7 +42,7 @@ func (rm *resourceManager) getTags(
 	return tags, nil
 }
 
-// updateTags updates tags of given ParameterGroup to desired tags.
+// updateTags updates tags of given SubnetGroup to desired tags.
 func (rm *resourceManager) updateTags(
 	ctx context.Context,
 	desired *resource,

--- a/pkg/resource/user/sdk.go
+++ b/pkg/resource/user/sdk.go
@@ -146,6 +146,11 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
+	ko.Status.Events, err = rm.getEvents(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
 	if rm.isUserActive(&resource{ko}) {
 		resourceARN := (*string)(ko.Status.ACKResourceMetadata.ARN)
 		tags, err := rm.getTags(ctx, *resourceARN)

--- a/pkg/util/events.go
+++ b/pkg/util/events.go
@@ -1,0 +1,64 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package util
+
+import (
+	"time"
+
+	svcsdk "github.com/aws/aws-sdk-go/service/memorydb"
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	svcapitypes "github.com/aws-controllers-k8s/memorydb-controller/apis/v1alpha1"
+)
+
+var (
+	// eventsDuration represents the maximum time range worth of
+	//events to retrieve.
+	eventsDuration = time.Duration(14*24) * time.Hour
+	// MaxEvents represents the maximum events can to retrieve.
+	MaxEvents = int64(20)
+)
+
+func NewDescribeEventsInput(
+	sourceName string,
+	sourceType string,
+	maxResults int64,
+) *svcsdk.DescribeEventsInput {
+	input := &svcsdk.DescribeEventsInput{}
+	input.SetSourceType(sourceType)
+	input.SetSourceName(sourceName)
+	input.SetMaxResults(maxResults)
+	input.SetDuration(int64(eventsDuration.Minutes()))
+	return input
+}
+
+// EventsFromDescribe returns a slice of Event structs given the
+// Output response shape from a DescribeEventsWithContext call
+func EventsFromDescribe(
+	resp *svcsdk.DescribeEventsOutput,
+) []*svcapitypes.Event {
+	events := lo.Map(resp.Events, func(respEvent *svcsdk.Event, index int) *svcapitypes.Event {
+		event := &svcapitypes.Event{
+			Message: respEvent.Message,
+		}
+		if respEvent.Date != nil {
+			eventDate := metav1.NewTime(*respEvent.Date)
+			event.Date = &eventDate
+		}
+		return event
+	})
+
+	return events
+}

--- a/templates/hooks/acl/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/acl/sdk_read_many_post_set_output.go.tpl
@@ -1,3 +1,8 @@
+    ko.Status.Events, err = rm.getEvents(ctx, r)
+    if err != nil {
+        return nil, err
+    }
+
     if rm.isACLActive(&resource{ko}) {
 		resourceARN := (*string)(ko.Status.ACKResourceMetadata.ARN)
 		tags, err := rm.getTags(ctx, *resourceARN)
@@ -6,3 +11,4 @@
 		}
 		ko.Spec.Tags = tags
 	}
+

--- a/templates/hooks/cluster/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/cluster/sdk_read_many_post_set_output.go.tpl
@@ -29,6 +29,11 @@
 		return nil, respErr
 	}
 
+    ko.Status.Events, err = rm.getEvents(ctx, r)
+    if err != nil {
+        return nil, err
+    }
+
     if rm.isClusterAvailable(&resource{ko}) {
 		resourceARN := (*string)(ko.Status.ACKResourceMetadata.ARN)
 		tags, err := rm.getTags(ctx, *resourceARN)

--- a/templates/hooks/user/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/user/sdk_read_many_post_set_output.go.tpl
@@ -1,3 +1,8 @@
+    ko.Status.Events, err = rm.getEvents(ctx, r)
+    if err != nil {
+        return nil, err
+    }
+
     if rm.isUserActive(&resource{ko}) {
 		resourceARN := (*string)(ko.Status.ACKResourceMetadata.ARN)
 		tags, err := rm.getTags(ctx, *resourceARN)

--- a/test/e2e/scenarios/ACL/acl_create_update.yaml
+++ b/test/e2e/scenarios/ACL/acl_create_update.yaml
@@ -85,8 +85,8 @@ steps:
       UserNames:
         - userone$RANDOM_SUFFIX
         - usertwo$RANDOM_SUFFIX
-  - id: "UPDATE_ACL_WITH_USERNAMES_AND_TAGS"
-    description: "Update userNames and tags"
+  - id: "UPDATE_ACL_USERNAMES_AND_TAGS_AND_VALIDATE_EVENTS"
+    description: "Update userNames and tags, and validate events"
     patch:
       apiVersion: $CRD_GROUP/$CRD_VERSION
       kind: ACL
@@ -105,6 +105,8 @@ steps:
             status: "True"
             timeout: 180
     expect_k8s:
+      status:
+        events:
       spec:
         userNames:
           - userone$RANDOM_SUFFIX

--- a/test/e2e/scenarios/Cluster/cluster_create_update.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_create_update.yaml
@@ -179,8 +179,8 @@ steps:
         name: pg$RANDOM_SUFFIX
     expect_aws:
       Name: pg$RANDOM_SUFFIX
-  - id: "UPDATE_PG"
-    description: "Update PG"
+  - id: "UPDATE_PG_AND_VALIDATE_EVENTS"
+    description: "Update PG and validate events"
     patch:
       apiVersion: $CRD_GROUP/$CRD_VERSION
       kind: Cluster
@@ -195,6 +195,8 @@ steps:
             status: "True"
             timeout: 180
     expect_k8s:
+      status:
+        events:
       spec:
         parameterGroupName: pg$RANDOM_SUFFIX
     expect_aws:

--- a/test/e2e/scenarios/User/user_create_update.yaml
+++ b/test/e2e/scenarios/User/user_create_update.yaml
@@ -112,8 +112,8 @@ steps:
               name: $SECRET1
     expect_aws:
       AccessString: on resetchannels -@all +get
-  - id: "REAPPLY_SPEC"
-    description: "Update Secret and AccessString we should not see any errors"
+  - id: "REAPPLY_SPEC_AND_VALIDATE_EVENTS"
+    description: "Update Secret and AccessString we should not see any errors. Events should present."
     patch:
       spec:
         accessString: on +get
@@ -129,6 +129,8 @@ steps:
             status: "True"
             timeout: 100
     expect_k8s:
+      status:
+        events:
       spec:
         accessString: on resetchannels -@all +get
         authenticationMode:

--- a/test/e2e/tests/test_scenarios.py
+++ b/test/e2e/tests/test_scenarios.py
@@ -121,6 +121,14 @@ class UserHelper(helper.ResourceHelper):
     Overrides methods as required for custom resources.
     """
 
+    def assert_extra_items_k8s(self, expected_name, expected_value, k8s_resource) -> bool:
+        # events are processed by custom logic
+        # returns AssertError if events are empty in k8s resource
+        if expected_name == "events":
+            assert k8s_resource.get(expected_name) is not None
+            return True
+        return False
+
     def get_aws_resource(self, resource_name):
         users = self.mdb.describe_users(UserName=resource_name)
         user = users['Users'][0]
@@ -171,6 +179,14 @@ class ACLHelper(helper.ResourceHelper):
     Overrides methods as required for custom resources.
     """
 
+    def assert_extra_items_k8s(self, expected_name, expected_value, k8s_resource) -> bool:
+        # events are processed by custom logic
+        # returns AssertError if events are empty in k8s resource
+        if expected_name == "events":
+            assert k8s_resource.get(expected_name) is not None
+            return True
+        return False
+
     def get_aws_resource(self, resource_name):
         acls = self.mdb.describe_acls(ACLName=resource_name)
         acl = acls['ACLs'][0]
@@ -186,6 +202,14 @@ class ClusterHelper(helper.ResourceHelper):
     Helper for Cluster scenarios.
     Overrides methods as required for custom resources.
     """
+
+    def assert_extra_items_k8s(self, expected_name, expected_value, k8s_resource) -> bool:
+        # events are processed by custom logic
+        # returns AssertError if events are empty in k8s resource
+        if expected_name == "events":
+            assert k8s_resource.get(expected_name) is not None
+            return True
+        return False
 
     def get_aws_resource(self, resource_name):
         clusters = self.mdb.describe_clusters(ClusterName=resource_name)


### PR DESCRIPTION
Issue #, if available:
Resources don't have `Events` field in MemoryDB controller.

Description of changes:
1. Support MemoryDB DescribeEvents for `ACL`, `Cluster`, `User`. Add `Events` field to those resources and add function to sync `Events` from service resource. 
2. Add a custom logic into test framework to validate present of `Events`, and add e2e yaml test file for each resource to validate `Events`.
3. Fix resource name errors in document.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
