### PR TITLE
Fix incorrect status of cluster and snapshot

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2023-02-23T20:04:23Z"
+  build_date: "2023-03-02T08:20:25Z"
   build_hash: d0f3d78cbea8061f822cbceac3786128f091efe6
   go_version: go1.19
   version: v0.24.2
@@ -7,7 +7,7 @@ api_directory_checksum: ee32acc4d4a0ba7e2823dd20fdbe2c4ef1d9e0f4
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: 19e41b58c6c4d1971db53e6c1694da632d71d053
+  file_checksum: 24db040eb331d4873d608c73f3318ae9cd11eb02
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -237,6 +237,11 @@ resources:
         DescribeSnapshots:
           input_fields:
             SnapshotName: Name
+    synced:
+      when:
+        - path: Status.Status
+          in:
+            - available
   ParameterGroup:
     exceptions:
       errors:

--- a/generator.yaml
+++ b/generator.yaml
@@ -237,6 +237,11 @@ resources:
         DescribeSnapshots:
           input_fields:
             SnapshotName: Name
+    synced:
+      when:
+        - path: Status.Status
+          in:
+            - available
   ParameterGroup:
     exceptions:
       errors:

--- a/pkg/resource/acl/hooks.go
+++ b/pkg/resource/acl/hooks.go
@@ -45,8 +45,8 @@ func (rm *resourceManager) validateACLNeedsUpdate(
 	return nil
 }
 
-// aclActive returns true when the status of the given ACL is set to `active`
-func (rm *resourceManager) aclActive(
+// isACLActive returns true when the status of the given ACL is set to `active`
+func (rm *resourceManager) isACLActive(
 	latest *resource,
 ) bool {
 	latestStatus := latest.ko.Status.Status

--- a/pkg/resource/acl/sdk.go
+++ b/pkg/resource/acl/sdk.go
@@ -164,7 +164,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
-	if rm.aclActive(&resource{ko}) {
+	if rm.isACLActive(&resource{ko}) {
 		resourceARN := (*string)(ko.Status.ACKResourceMetadata.ARN)
 		tags, err := rm.getTags(ctx, *resourceARN)
 		if err != nil {

--- a/pkg/resource/cluster/hooks.go
+++ b/pkg/resource/cluster/hooks.go
@@ -31,7 +31,7 @@ import (
 var (
 	condMsgCurrentlyDeleting            = "cluster currently being deleted"
 	condMsgNoDeleteWhileUpdating        = "cluster is being updated. cannot delete"
-	resourceStatusActive         string = "active"
+	resourceStatusAvailable      string = "available"
 )
 
 var (
@@ -264,12 +264,12 @@ func (rm *resourceManager) newMemoryDBClusterUploadPayload(
 	return res
 }
 
-// clusterActive returns true when the status of the given Cluster is set to `active`
-func (rm *resourceManager) clusterActive(
+// isClusterAvailable returns true when the status of the given Cluster is set to `available`
+func (rm *resourceManager) isClusterAvailable(
 	latest *resource,
 ) bool {
 	latestStatus := latest.ko.Status.Status
-	return latestStatus != nil && *latestStatus == resourceStatusActive
+	return latestStatus != nil && *latestStatus == resourceStatusAvailable
 }
 
 // getTags gets tags from given ParameterGroup.

--- a/pkg/resource/cluster/sdk.go
+++ b/pkg/resource/cluster/sdk.go
@@ -352,7 +352,7 @@ func (rm *resourceManager) sdkFind(
 		return nil, respErr
 	}
 
-	if rm.clusterActive(&resource{ko}) {
+	if rm.isClusterAvailable(&resource{ko}) {
 		resourceARN := (*string)(ko.Status.ACKResourceMetadata.ARN)
 		tags, err := rm.getTags(ctx, *resourceARN)
 		if err != nil {

--- a/pkg/resource/snapshot/hooks.go
+++ b/pkg/resource/snapshot/hooks.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	resourceStatusActive string = "active"
+	resourceStatusAvailable string = "available"
 )
 
 func (rm *resourceManager) customDescribeSnapshotSetOutput(
@@ -251,12 +251,12 @@ func (rm *resourceManager) newCopySnapshotPayload(
 	return res, nil
 }
 
-// snapshotActive returns true when the status of the given Snapshot is set to `active`
-func (rm *resourceManager) snapshotActive(
+// isSnapshotAvailable returns true when the status of the given Snapshot is set to `available`
+func (rm *resourceManager) isSnapshotAvailable(
 	latest *resource,
 ) bool {
 	latestStatus := latest.ko.Status.Status
-	return latestStatus != nil && *latestStatus == resourceStatusActive
+	return latestStatus != nil && *latestStatus == resourceStatusAvailable
 }
 
 // getTags gets tags from given ParameterGroup.

--- a/pkg/resource/snapshot/manager.go
+++ b/pkg/resource/snapshot/manager.go
@@ -268,6 +268,14 @@ func (rm *resourceManager) IsSynced(ctx context.Context, res acktypes.AWSResourc
 		panic("resource manager's IsSynced() method received resource with nil CR object")
 	}
 
+	if r.ko.Status.Status == nil {
+		return false, nil
+	}
+	statusCandidates := []string{"available"}
+	if !ackutil.InStrings(*r.ko.Status.Status, statusCandidates) {
+		return false, nil
+	}
+
 	return true, nil
 }
 

--- a/pkg/resource/snapshot/sdk.go
+++ b/pkg/resource/snapshot/sdk.go
@@ -201,7 +201,7 @@ func (rm *resourceManager) sdkFind(
 		return nil, err
 	}
 
-	if rm.snapshotActive(&resource{ko}) {
+	if rm.isSnapshotAvailable(&resource{ko}) {
 		resourceARN := (*string)(ko.Status.ACKResourceMetadata.ARN)
 		tags, err := rm.getTags(ctx, *resourceARN)
 		if err != nil {

--- a/pkg/resource/user/hooks.go
+++ b/pkg/resource/user/hooks.go
@@ -58,8 +58,8 @@ func (rm *resourceManager) validateUserNeedsUpdate(
 	return nil, nil
 }
 
-// userActive returns true when the status of the given User is set to `active`
-func (rm *resourceManager) userActive(
+// isUserActive returns true when the status of the given User is set to `active`
+func (rm *resourceManager) isUserActive(
 	latest *resource,
 ) bool {
 	latestStatus := latest.ko.Status.Status

--- a/pkg/resource/user/sdk.go
+++ b/pkg/resource/user/sdk.go
@@ -146,7 +146,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
-	if rm.userActive(&resource{ko}) {
+	if rm.isUserActive(&resource{ko}) {
 		resourceARN := (*string)(ko.Status.ACKResourceMetadata.ARN)
 		tags, err := rm.getTags(ctx, *resourceARN)
 		if err != nil {

--- a/templates/hooks/acl/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/acl/sdk_read_many_post_set_output.go.tpl
@@ -1,4 +1,4 @@
-    if rm.aclActive(&resource{ko}) {
+    if rm.isACLActive(&resource{ko}) {
 		resourceARN := (*string)(ko.Status.ACKResourceMetadata.ARN)
 		tags, err := rm.getTags(ctx, *resourceARN)
 		if err != nil {

--- a/templates/hooks/cluster/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/cluster/sdk_read_many_post_set_output.go.tpl
@@ -29,7 +29,7 @@
 		return nil, respErr
 	}
 
-    if rm.clusterActive(&resource{ko}) {
+    if rm.isClusterAvailable(&resource{ko}) {
 		resourceARN := (*string)(ko.Status.ACKResourceMetadata.ARN)
 		tags, err := rm.getTags(ctx, *resourceARN)
 		if err != nil {

--- a/templates/hooks/snapshot/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/snapshot/sdk_read_many_post_set_output.go.tpl
@@ -4,7 +4,7 @@
     	return nil, err
     }
 
-    if rm.snapshotActive(&resource{ko}) {
+    if rm.isSnapshotAvailable(&resource{ko}) {
 		resourceARN := (*string)(ko.Status.ACKResourceMetadata.ARN)
 		tags, err := rm.getTags(ctx, *resourceARN)
 		if err != nil {

--- a/templates/hooks/user/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/user/sdk_read_many_post_set_output.go.tpl
@@ -1,4 +1,4 @@
-    if rm.userActive(&resource{ko}) {
+    if rm.isUserActive(&resource{ko}) {
 		resourceARN := (*string)(ko.Status.ACKResourceMetadata.ARN)
 		tags, err := rm.getTags(ctx, *resourceARN)
 		if err != nil {

--- a/test/e2e/scenarios/Cluster/cluster_update_with_tags.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_update_with_tags.yaml
@@ -53,12 +53,12 @@ steps:
             value: "test_value_1"
           - key: "test_key_2"
             value: "test_value_2"
-#    expect_aws:
-#      Tags:
-#        - Key: "test_key_1"
-#          Value: "test_value_1"
-#        - Key: "test_key_2"
-#          Value: "test_value_2"
+    expect_aws:
+      Tags:
+        - Key: "test_key_1"
+          Value: "test_value_1"
+        - Key: "test_key_2"
+          Value: "test_value_2"
   - id: "CLUSTER_DELETE_TAGS"
     description: "Delete tags in Cluster"
     patch:
@@ -81,10 +81,10 @@ steps:
         tags:
           - key: "test_key_1"
             value: "test_value_1"
-#    expect_aws:
-#      Tags:
-#        - Key: "test_key_1"
-#          Value: "test_value_1"
+    expect_aws:
+      Tags:
+        - Key: "test_key_1"
+          Value: "test_value_1"
   - id: "Cluster_ADD_AND_DELETE_TAGS"
     description: "Add some tags and delete some tags in Cluster"
     patch:
@@ -107,10 +107,10 @@ steps:
         tags:
           - key: "test_key_2"
             value: "test_value_3"
-#    expect_aws:
-#      Tags:
-#        - Key: "test_key_2"
-#          Value: "test_value_3"
+    expect_aws:
+      Tags:
+        - Key: "test_key_2"
+          Value: "test_value_3"
   - id: "DELETE_CLUSTER"
     description: "Delete the cluster"
     delete:

--- a/test/e2e/scenarios/Snapshot/snapshot_update_with_tags.yaml
+++ b/test/e2e/scenarios/Snapshot/snapshot_update_with_tags.yaml
@@ -77,12 +77,12 @@ steps:
             value: "test_value_1"
           - key: "test_key_2"
             value: "test_value_2"
-#    expect_aws:
-#      Tags:
-#        - Key: "test_key_1"
-#          Value: "test_value_1"
-#        - Key: "test_key_2"
-#          Value: "test_value_2"
+    expect_aws:
+      Tags:
+        - Key: "test_key_1"
+          Value: "test_value_1"
+        - Key: "test_key_2"
+          Value: "test_value_2"
   - id: "SNAPSHOT_DELETE_TAGS"
     description: "Delete tags in snapshot"
     patch:
@@ -105,10 +105,10 @@ steps:
         tags:
           - key: "test_key_1"
             value: "test_value_1"
-#    expect_aws:
-#      Tags:
-#        - Key: "test_key_1"
-#          Value: "test_value_1"
+    expect_aws:
+      Tags:
+        - Key: "test_key_1"
+          Value: "test_value_1"
   - id: "SNAPSHOT_ADD_AND_DELETE_TAGS"
     description: "Add some tags and delete tags in snapshot"
     patch:
@@ -131,10 +131,10 @@ steps:
         tags:
           - key: "test_key_2"
             value: "test_value_3"
-#    expect_aws:
-#      Tags:
-#        - Key: "test_key_2"
-#          Value: "test_value_3"
+    expect_aws:
+      Tags:
+        - Key: "test_key_2"
+          Value: "test_value_3"
   - id: "DELETE_SNAPSHOT"
     description: "Delete snapshot"
     delete:


### PR DESCRIPTION
Issue #, if available:
1. `status` of cluster and snapshot should be `available` instead of `active`.
2. names of function for checking `status` of resources are not proper.

Description of changes:
1. Add `synced` of snapshot into generator. Correct `status` of cluster and snapshot from `active` to `available`.
2. Uncomment some parts in two yaml test files related to tags update of cluster and snapshot.
3. Modify functions for checking `status` of cluster, snapshot, acl, user to proper names.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
