### PR TITLE
Ignore ClusterName for copySnapshot API

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2023-02-03T00:39:12Z"
-  build_hash: c6651c200ba136e5c7f50ad8be751fae060a38e6
+  build_date: "2023-02-07T22:28:52Z"
+  build_hash: b55ae8752ece381c383ffe5b388ed2147c6b30d8
   go_version: go1.19
-  version: v0.22.0-1-gc6651c2
+  version: v0.23.1
 api_directory_checksum: ee32acc4d4a0ba7e2823dd20fdbe2c4ef1d9e0f4
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: d7ad13c5bc8d9e9e2171c92dc3ac51c2b5e3b769
+  file_checksum: 19e41b58c6c4d1971db53e6c1694da632d71d053
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -209,6 +209,7 @@ resources:
           path: SourceSnapshotName
       ClusterName:
         is_primary_key: false
+        is_required: false
         from:
           operation: CreateSnapshot
           path: ClusterName

--- a/config/controller/deployment.yaml
+++ b/config/controller/deployment.yaml
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  labels:
-    control-plane: controller
   name: ack-system
 ---
 apiVersion: apps/v1
@@ -11,16 +9,17 @@ metadata:
   name: ack-memorydb-controller
   namespace: ack-system
   labels:
-    control-plane: controller
+    app.kubernetes.io/name: ack-memorydb-controller
+    app.kubernetes.io/part-of: ack-system
 spec:
   selector:
     matchLabels:
-      control-plane: controller
+      app.kubernetes.io/name: ack-memorydb-controller
   replicas: 1
   template:
     metadata:
       labels:
-        control-plane: controller
+        app.kubernetes.io/name: ack-memorydb-controller
     spec:
       containers:
       - command:

--- a/config/controller/service.yaml
+++ b/config/controller/service.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: ack-system
 spec:
   selector:
-    control-plane: controller
+    app.kubernetes.io/name: ack-memorydb-controller
   ports:
     - name: metricsport
       port: 8080

--- a/generator.yaml
+++ b/generator.yaml
@@ -209,6 +209,7 @@ resources:
           path: SourceSnapshotName
       ClusterName:
         is_primary_key: false
+        is_required: false
         from:
           operation: CreateSnapshot
           path: ClusterName

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
     k8s-app: {{ include "app.name" . }}
     helm.sh/chart: {{ include "chart.name-version" . }}
-    control-plane: controller
 spec:
   replicas: 1
   selector:

--- a/helm/templates/metrics-service.yaml
+++ b/helm/templates/metrics-service.yaml
@@ -11,7 +11,6 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
     k8s-app: {{ include "app.name" . }}
     helm.sh/chart: {{ include "chart.name-version" . }}
-    control-plane: controller
 spec:
   selector:
     app.kubernetes.io/name: {{ include "app.name" . }}


### PR DESCRIPTION
Issue #, if available:
v0.23.1 code-controller considers ClusterName as required field for snapshot, but memorydb copySnapshot API should have empty ClusterName.

Description of changes:
Set is_required value of ClusterName to false for snapshot.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
