### PR TITLE
Add patching objects with tags tests

### DIFF
--- a/test/e2e/scenarios/ACL/acl_create_update.yaml
+++ b/test/e2e/scenarios/ACL/acl_create_update.yaml
@@ -85,8 +85,8 @@ steps:
       UserNames:
         - userone$RANDOM_SUFFIX
         - usertwo$RANDOM_SUFFIX
-  - id: "UPDATE_ACL"
-    description: "Update userNames"
+  - id: "UPDATE_ACL_WITH_USERNAMES_AND_TAGS"
+    description: "Update userNames and tags"
     patch:
       apiVersion: $CRD_GROUP/$CRD_VERSION
       kind: ACL
@@ -95,6 +95,9 @@ steps:
       spec:
         userNames:
           - userone$RANDOM_SUFFIX
+        tags:
+          - key: "test_key_1"
+            value: "test_value_1"
     wait:
       status:
         conditions:
@@ -105,9 +108,15 @@ steps:
       spec:
         userNames:
           - userone$RANDOM_SUFFIX
+        tags:
+          - key: "test_key_1"
+            value: "test_value_1"
     expect_aws:
       UserNames:
         - userone$RANDOM_SUFFIX
+      Tags:
+        - Key: "test_key_1"
+          Value: "test_value_1"
   - id: "ACL_DELETE"
     description: "Delete ACL"
     delete:

--- a/test/e2e/scenarios/Cluster/cluster_create_update.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_create_update.yaml
@@ -125,8 +125,8 @@ steps:
         name: acl$RANDOM_SUFFIX
     expect_aws:
       Name: acl$RANDOM_SUFFIX
-  - id: "UPDATE_ACL"
-    description: "Update ACL"
+  - id: "UPDATE_ACL_AND_TAGS"
+    description: "Update ACL and tags"
     patch:
       apiVersion: $CRD_GROUP/$CRD_VERSION
       kind: Cluster
@@ -134,6 +134,9 @@ steps:
         name: cluster$RANDOM_SUFFIX
       spec:
         aclName: acl$RANDOM_SUFFIX
+        tags:
+          - key: "test_key_1"
+            value: "test_value_1"
     wait:
       status:
         conditions:
@@ -143,8 +146,14 @@ steps:
     expect_k8s:
       spec:
         aclName: acl$RANDOM_SUFFIX
+        tags:
+          - key: "test_key_1"
+            value: "test_value_1"
     expect_aws:
       ACLName: acl$RANDOM_SUFFIX
+      Tags:
+        - Key: "test_key_1"
+          Value: "test_value_1"
   - id: "PG_INITIAL_CREATE"
     description: "PG with activerehashing as no"
     create:

--- a/test/e2e/scenarios/ParameterGroup/pg_update_with_params_and_reset.yaml
+++ b/test/e2e/scenarios/ParameterGroup/pg_update_with_params_and_reset.yaml
@@ -167,8 +167,8 @@ steps:
           Value: "3001"
         - Name: lazyfree-lazy-eviction
           Value: "yes"
-  - id: "PG_UPDATE_SECOND_HALF_PARAMETERS"
-    description: "Update rest 19 parameters at the same time"
+  - id: "PG_UPDATE_SECOND_HALF_PARAMETERS_AND_TAGS"
+    description: "Update rest 19 parameters and tags at the same time"
     patch:
       spec:
         parameterNameValues:
@@ -210,6 +210,9 @@ steps:
             parameterValue: "127"
           - parameterName: zset-max-ziplist-value
             parameterValue: "63"
+        tags:
+          - key: "test_key_1"
+            value: "test_value_1"
     wait:
       status:
         conditions:
@@ -257,6 +260,9 @@ steps:
             parameterValue: "127"
           - parameterName: zset-max-ziplist-value
             parameterValue: "63"
+        tags:
+          - key: "test_key_1"
+            value: "test_value_1"
     expect_aws:
       Parameters:
         - Name: lazyfree-lazy-expire
@@ -297,6 +303,9 @@ steps:
           Value: "127"
         - Name: zset-max-ziplist-value
           Value: "63"
+      Tags:
+        - Key: "test_key_1"
+          Value: "test_value_1"
   - id: "PG_RESET"
     description: "Update parameterNameValues to empty list"
     patch:

--- a/test/e2e/scenarios/SubnetGroup/subnetgroup_create_update.yaml
+++ b/test/e2e/scenarios/SubnetGroup/subnetgroup_create_update.yaml
@@ -50,7 +50,7 @@ steps:
         description: Subnet group update
     expect_aws:
       Description: Subnet group update
-  - id: "UPDATE_SUBNET"
+  - id: "UPDATE_SUBNETS"
     description: "Update SubnetGroup SubnetIds"
     patch:
       spec:
@@ -69,14 +69,17 @@ steps:
     expect_aws:
       Subnets:
         - Identifier: $SUBNET2
-  - id: "UPDATE_SUBNET_DESCRIPTION"
-    description: "Update SubnetGroup SubnetIds and Description"
+  - id: "UPDATE_SUBNETS_DESCRIPTION_AND_TAGS"
+    description: "Update SubnetGroup SubnetIds, Description, and Tags"
     patch:
       spec:
         description: Subnet group update description and subnets
         subnetIDs:
           - $SUBNET1
           - $SUBNET2
+        tags:
+          - key: "test_key_1"
+            value: "test_value_1"
     wait:
       status:
         conditions:
@@ -89,6 +92,9 @@ steps:
         subnetIDs:
           - $SUBNET1
           - $SUBNET2
+        tags:
+          - key: "test_key_1"
+            value: "test_value_1"
     expect_aws:
       Description: Subnet group update description and subnets
       Subnets:

--- a/test/e2e/scenarios/User/user_create_update.yaml
+++ b/test/e2e/scenarios/User/user_create_update.yaml
@@ -1,5 +1,5 @@
 id: "USER_CREATE_UPDATE"
-description: "In this test we create User and Update"
+description: "In this test we create User and update it"
 #marks:
 #  - slow
 #  - blocked
@@ -54,8 +54,8 @@ steps:
         accessString: off resetchannels -@all +get
     expect_aws:
       AccessString: off resetchannels -@all +get
-  - id: "USER_UPDATE_PASSWORD"
-    description: "Update Password"
+  - id: "USER_UPDATE_PASSWORD_AND_TAGS"
+    description: "Update Password and Tags"
     patch:
       spec:
         authenticationMode:
@@ -63,6 +63,9 @@ steps:
           passwords:
             - key: password
               name: $SECRET2
+        tags:
+          - key: "test_key_1"
+            value: "test_value_1"
     wait:
       status:
         conditions:
@@ -76,6 +79,13 @@ steps:
           passwords:
             - key: password
               name: $SECRET2
+        tags:
+          - key: "test_key_1"
+            value: "test_value_1"
+    expect_aws:
+      Tags:
+        - Key: "test_key_1"
+          Value: "test_value_1"
   - id: "USER_UPDATE_ACCESS_STRING_AND_SECRET"
     description: "Update Secret and AccessString"
     patch:


### PR DESCRIPTION
Issue #, if available:
Need to validate that tags could be added together with modification of other fields.

Description of changes:
Add changes of tags together while modifying other fields.
Remove a redundant test step.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
