### PR TITLE
Modify snapshotRetentionLimit to 0 for cluster creations.

### DIFF
--- a/test/e2e/bootstrappable/cluster.py
+++ b/test/e2e/bootstrappable/cluster.py
@@ -26,7 +26,7 @@ class Cluster(Bootstrappable):
     def create_cluster(self):
         mdb = boto3.client("memorydb")
         mdb.create_cluster(ClusterName=self.clusterName,
-                           Description='Cluster for Ack snapshot resource testing',
+                           Description='Cluster for Ack snapshot resource testing', SnapshotRetentionLimit=0,
                            NodeType='db.r6g.large', ACLName='open-access', NumShards=1, NumReplicasPerShard=0)
         timeout = time.time() + 30*60  # 30 minutes from now
         available_status = "Available"

--- a/test/e2e/scenarios/Cluster/cluster_create_update.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_create_update.yaml
@@ -77,29 +77,6 @@ steps:
       Description: Test step 2 from ACK
       SnsTopicArn: $TOPIC2
       MaintenanceWindow: thu:09:00-thu:10:00
-  - id: "UPDATE_SNAPSHOT_WINDOW_RETENTION_LIMIT"
-    description: "Update snapshot window and retention limit"
-    patch:
-      apiVersion: $CRD_GROUP/$CRD_VERSION
-      kind: Cluster
-      metadata:
-        name: cluster$RANDOM_SUFFIX
-      spec:
-        snapshotWindow: 08:00-09:00
-        snapshotRetentionLimit: 10
-    wait:
-      status:
-        conditions:
-          ACK.ResourceSynced:
-            status: "True"
-            timeout: 3600
-    expect_k8s:
-      spec:
-        snapshotWindow: 08:00-09:00
-        snapshotRetentionLimit: 10
-    expect_aws:
-      SnapshotWindow: 08:00-09:00
-      SnapshotRetentionLimit: 10
   - id: "USER_CREATE"
     description: "Create User"
     create:
@@ -162,7 +139,7 @@ steps:
         conditions:
           ACK.ResourceSynced:
             status: "True"
-            timeout: 3600
+            timeout: 180
     expect_k8s:
       spec:
         aclName: acl$RANDOM_SUFFIX
@@ -213,6 +190,29 @@ steps:
         parameterGroupName: pg$RANDOM_SUFFIX
     expect_aws:
       ParameterGroupName: pg$RANDOM_SUFFIX
+  - id: "UPDATE_SNAPSHOT_WINDOW_RETENTION_LIMIT"
+    description: "Update snapshot window and retention limit"
+    patch:
+      apiVersion: $CRD_GROUP/$CRD_VERSION
+      kind: Cluster
+      metadata:
+        name: cluster$RANDOM_SUFFIX
+      spec:
+        snapshotWindow: 08:00-09:00
+        snapshotRetentionLimit: 10
+    wait:
+      status:
+        conditions:
+          ACK.ResourceSynced:
+            status: "True"
+            timeout: 3600
+    expect_k8s:
+      spec:
+        snapshotWindow: 08:00-09:00
+        snapshotRetentionLimit: 10
+    expect_aws:
+      SnapshotWindow: 08:00-09:00
+      SnapshotRetentionLimit: 10
   - id: "DELETE_CLUSTER"
     description: "Delete the cluster"
     delete:

--- a/test/e2e/scenarios/Cluster/cluster_terminal_condition.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_terminal_condition.yaml
@@ -16,6 +16,7 @@ steps:
         nodeType: cache.t4g.medium
         aclName: open-access
         numShards: 2
+        snapshotRetentionLimit: 0
     wait:
       status:
         conditions:

--- a/test/e2e/scenarios/Cluster/cluster_update_with_tags.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_update_with_tags.yaml
@@ -16,12 +16,13 @@ steps:
         nodeType: db.t4g.small
         aclName: open-access
         numShards: 1
+        snapshotRetentionLimit: 0
     wait:
       status:
         conditions:
           ACK.ResourceSynced:
             status: "True"
-            timeout: 7200
+            timeout: 1800
     expect_k8s:
       spec:
         name: cluster$RANDOM_SUFFIX

--- a/test/e2e/scenarios/Snapshot/snapshot_update_with_tags.yaml
+++ b/test/e2e/scenarios/Snapshot/snapshot_update_with_tags.yaml
@@ -16,12 +16,13 @@ steps:
         nodeType: db.t4g.small
         aclName: open-access
         numShards: 1
+        snapshotRetentionLimit: 0
     wait:
       status:
         conditions:
           ACK.ResourceSynced:
             status: "True"
-            timeout: 7200
+            timeout: 1800
     expect_k8s:
       spec:
         name: cluster$RANDOM_SUFFIX
@@ -42,7 +43,7 @@ steps:
         conditions:
           ACK.ResourceSynced:
             status: "True"
-            timeout: 3600
+            timeout: 1800
     expect_k8s:
       spec:
         clusterName: cluster$RANDOM_SUFFIX


### PR DESCRIPTION
Issue #, if available:
Snapshot window sometimes causes additional snapshotting process during cluster creation which takes additional time.

Description of changes:
Modify snapshotRetentionLimit to 0 for cluster creations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
