### PR TITLE
Update updateTags function by using new runtime function

### DIFF
--- a/pkg/resource/cluster/hooks.go
+++ b/pkg/resource/cluster/hooks.go
@@ -23,7 +23,6 @@ import (
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
-	ackutil "github.com/aws-controllers-k8s/runtime/pkg/util"
 	svcsdk "github.com/aws/aws-sdk-go/service/memorydb"
 
 	svcapitypes "github.com/aws-controllers-k8s/memorydb-controller/apis/v1alpha1"
@@ -304,9 +303,18 @@ func (rm *resourceManager) updateTags(
 
 	arn := (*string)(latest.ko.Status.ACKResourceMetadata.ARN)
 
-	toAdd, toDelete := computeTagsDelta(
-		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
-	)
+	desiredTags := ToACKTags(desired.ko.Spec.Tags)
+	latestTags := ToACKTags(latest.ko.Spec.Tags)
+
+	added, _, removed := ackcompare.GetTagsDifference(latestTags, desiredTags)
+
+	toAdd := FromACKTags(added)
+	toRemove := FromACKTags(removed)
+
+	var toDelete []*string
+	for _, removedElement := range toRemove {
+		toDelete = append(toDelete, removedElement.Key)
+	}
 
 	if len(toDelete) > 0 {
 		rlog.Debug("removing tags from cluster", "tags", toDelete)
@@ -341,38 +349,6 @@ func (rm *resourceManager) updateTags(
 	return nil
 }
 
-func computeTagsDelta(
-	desired []*svcapitypes.Tag,
-	latest []*svcapitypes.Tag,
-) (addedOrUpdated []*svcapitypes.Tag, removed []*string) {
-	var visitedIndexes []string
-	var hasSameKey bool
-
-	for _, latestElement := range latest {
-		hasSameKey = false
-		visitedIndexes = append(visitedIndexes, *latestElement.Key)
-		for _, desiredElement := range desired {
-			if equalStrings(latestElement.Key, desiredElement.Key) {
-				hasSameKey = true
-				if !equalStrings(latestElement.Value, desiredElement.Value) {
-					addedOrUpdated = append(addedOrUpdated, desiredElement)
-				}
-				break
-			}
-		}
-		if hasSameKey {
-			continue
-		}
-		removed = append(removed, latestElement.Key)
-	}
-	for _, desiredElement := range desired {
-		if !ackutil.InStrings(*desiredElement.Key, visitedIndexes) {
-			addedOrUpdated = append(addedOrUpdated, desiredElement)
-		}
-	}
-	return addedOrUpdated, removed
-}
-
 func sdkTagsFromResourceTags(
 	rTags []*svcapitypes.Tag,
 ) []*svcsdk.Tag {
@@ -397,13 +373,4 @@ func resourceTagsFromSDKTags(
 		}
 	}
 	return tags
-}
-
-func equalStrings(a, b *string) bool {
-	if a == nil {
-		return b == nil
-	} else if b == nil {
-		return false
-	}
-	return *a == *b
 }

--- a/pkg/resource/parameter_group/hooks.go
+++ b/pkg/resource/parameter_group/hooks.go
@@ -17,9 +17,9 @@ import (
 	"context"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
-	ackutil "github.com/aws-controllers-k8s/runtime/pkg/util"
 	svcsdk "github.com/aws/aws-sdk-go/service/memorydb"
 
 	svcapitypes "github.com/aws-controllers-k8s/memorydb-controller/apis/v1alpha1"
@@ -189,9 +189,18 @@ func (rm *resourceManager) updateTags(
 
 	arn := (*string)(latest.ko.Status.ACKResourceMetadata.ARN)
 
-	toAdd, toDelete := computeTagsDelta(
-		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
-	)
+	desiredTags := ToACKTags(desired.ko.Spec.Tags)
+	latestTags := ToACKTags(latest.ko.Spec.Tags)
+
+	added, _, removed := ackcompare.GetTagsDifference(latestTags, desiredTags)
+
+	toAdd := FromACKTags(added)
+	toRemove := FromACKTags(removed)
+
+	var toDelete []*string
+	for _, removedElement := range toRemove {
+		toDelete = append(toDelete, removedElement.Key)
+	}
 
 	if len(toDelete) > 0 {
 		rlog.Debug("removing tags from parameter group", "tags", toDelete)
@@ -226,38 +235,6 @@ func (rm *resourceManager) updateTags(
 	return nil
 }
 
-func computeTagsDelta(
-	desired []*svcapitypes.Tag,
-	latest []*svcapitypes.Tag,
-) (addedOrUpdated []*svcapitypes.Tag, removed []*string) {
-	var visitedIndexes []string
-	var hasSameKey bool
-
-	for _, latestElement := range latest {
-		hasSameKey = false
-		visitedIndexes = append(visitedIndexes, *latestElement.Key)
-		for _, desiredElement := range desired {
-			if equalStrings(latestElement.Key, desiredElement.Key) {
-				hasSameKey = true
-				if !equalStrings(latestElement.Value, desiredElement.Value) {
-					addedOrUpdated = append(addedOrUpdated, desiredElement)
-				}
-				break
-			}
-		}
-		if hasSameKey {
-			continue
-		}
-		removed = append(removed, latestElement.Key)
-	}
-	for _, desiredElement := range desired {
-		if !ackutil.InStrings(*desiredElement.Key, visitedIndexes) {
-			addedOrUpdated = append(addedOrUpdated, desiredElement)
-		}
-	}
-	return addedOrUpdated, removed
-}
-
 func sdkTagsFromResourceTags(
 	rTags []*svcapitypes.Tag,
 ) []*svcsdk.Tag {
@@ -282,13 +259,4 @@ func resourceTagsFromSDKTags(
 		}
 	}
 	return tags
-}
-
-func equalStrings(a, b *string) bool {
-	if a == nil {
-		return b == nil
-	} else if b == nil {
-		return false
-	}
-	return *a == *b
 }

--- a/pkg/resource/snapshot/hooks.go
+++ b/pkg/resource/snapshot/hooks.go
@@ -21,7 +21,6 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
-	ackutil "github.com/aws-controllers-k8s/runtime/pkg/util"
 	svcsdk "github.com/aws/aws-sdk-go/service/memorydb"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -308,9 +307,18 @@ func (rm *resourceManager) updateTags(
 
 	arn := (*string)(latest.ko.Status.ACKResourceMetadata.ARN)
 
-	toAdd, toDelete := computeTagsDelta(
-		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
-	)
+	desiredTags := ToACKTags(desired.ko.Spec.Tags)
+	latestTags := ToACKTags(latest.ko.Spec.Tags)
+
+	added, _, removed := ackcompare.GetTagsDifference(latestTags, desiredTags)
+
+	toAdd := FromACKTags(added)
+	toRemove := FromACKTags(removed)
+
+	var toDelete []*string
+	for _, removedElement := range toRemove {
+		toDelete = append(toDelete, removedElement.Key)
+	}
 
 	if len(toDelete) > 0 {
 		rlog.Debug("removing tags from snapshot", "tags", toDelete)
@@ -345,38 +353,6 @@ func (rm *resourceManager) updateTags(
 	return nil
 }
 
-func computeTagsDelta(
-	desired []*svcapitypes.Tag,
-	latest []*svcapitypes.Tag,
-) (addedOrUpdated []*svcapitypes.Tag, removed []*string) {
-	var visitedIndexes []string
-	var hasSameKey bool
-
-	for _, latestElement := range latest {
-		hasSameKey = false
-		visitedIndexes = append(visitedIndexes, *latestElement.Key)
-		for _, desiredElement := range desired {
-			if equalStrings(latestElement.Key, desiredElement.Key) {
-				hasSameKey = true
-				if !equalStrings(latestElement.Value, desiredElement.Value) {
-					addedOrUpdated = append(addedOrUpdated, desiredElement)
-				}
-				break
-			}
-		}
-		if hasSameKey {
-			continue
-		}
-		removed = append(removed, latestElement.Key)
-	}
-	for _, desiredElement := range desired {
-		if !ackutil.InStrings(*desiredElement.Key, visitedIndexes) {
-			addedOrUpdated = append(addedOrUpdated, desiredElement)
-		}
-	}
-	return addedOrUpdated, removed
-}
-
 func sdkTagsFromResourceTags(
 	rTags []*svcapitypes.Tag,
 ) []*svcsdk.Tag {
@@ -401,13 +377,4 @@ func resourceTagsFromSDKTags(
 		}
 	}
 	return tags
-}
-
-func equalStrings(a, b *string) bool {
-	if a == nil {
-		return b == nil
-	} else if b == nil {
-		return false
-	}
-	return *a == *b
 }

--- a/pkg/resource/subnet_group/hooks.go
+++ b/pkg/resource/subnet_group/hooks.go
@@ -16,8 +16,8 @@ package subnet_group
 import (
 	"context"
 
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
-	ackutil "github.com/aws-controllers-k8s/runtime/pkg/util"
 	svcsdk "github.com/aws/aws-sdk-go/service/memorydb"
 
 	svcapitypes "github.com/aws-controllers-k8s/memorydb-controller/apis/v1alpha1"
@@ -54,9 +54,18 @@ func (rm *resourceManager) updateTags(
 
 	arn := (*string)(latest.ko.Status.ACKResourceMetadata.ARN)
 
-	toAdd, toDelete := computeTagsDelta(
-		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
-	)
+	desiredTags := ToACKTags(desired.ko.Spec.Tags)
+	latestTags := ToACKTags(latest.ko.Spec.Tags)
+
+	added, _, removed := ackcompare.GetTagsDifference(latestTags, desiredTags)
+
+	toAdd := FromACKTags(added)
+	toRemove := FromACKTags(removed)
+
+	var toDelete []*string
+	for _, removedElement := range toRemove {
+		toDelete = append(toDelete, removedElement.Key)
+	}
 
 	if len(toDelete) > 0 {
 		rlog.Debug("removing tags from parameter group", "tags", toDelete)
@@ -91,38 +100,6 @@ func (rm *resourceManager) updateTags(
 	return nil
 }
 
-func computeTagsDelta(
-	desired []*svcapitypes.Tag,
-	latest []*svcapitypes.Tag,
-) (addedOrUpdated []*svcapitypes.Tag, removed []*string) {
-	var visitedIndexes []string
-	var hasSameKey bool
-
-	for _, latestElement := range latest {
-		hasSameKey = false
-		visitedIndexes = append(visitedIndexes, *latestElement.Key)
-		for _, desiredElement := range desired {
-			if equalStrings(latestElement.Key, desiredElement.Key) {
-				hasSameKey = true
-				if !equalStrings(latestElement.Value, desiredElement.Value) {
-					addedOrUpdated = append(addedOrUpdated, desiredElement)
-				}
-				break
-			}
-		}
-		if hasSameKey {
-			continue
-		}
-		removed = append(removed, latestElement.Key)
-	}
-	for _, desiredElement := range desired {
-		if !ackutil.InStrings(*desiredElement.Key, visitedIndexes) {
-			addedOrUpdated = append(addedOrUpdated, desiredElement)
-		}
-	}
-	return addedOrUpdated, removed
-}
-
 func sdkTagsFromResourceTags(
 	rTags []*svcapitypes.Tag,
 ) []*svcsdk.Tag {
@@ -147,13 +124,4 @@ func resourceTagsFromSDKTags(
 		}
 	}
 	return tags
-}
-
-func equalStrings(a, b *string) bool {
-	if a == nil {
-		return b == nil
-	} else if b == nil {
-		return false
-	}
-	return *a == *b
 }

--- a/pkg/resource/user/hooks.go
+++ b/pkg/resource/user/hooks.go
@@ -20,7 +20,6 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	"github.com/aws-controllers-k8s/runtime/pkg/requeue"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
-	ackutil "github.com/aws-controllers-k8s/runtime/pkg/util"
 	svcsdk "github.com/aws/aws-sdk-go/service/memorydb"
 
 	svcapitypes "github.com/aws-controllers-k8s/memorydb-controller/apis/v1alpha1"
@@ -104,9 +103,18 @@ func (rm *resourceManager) updateTags(
 
 	arn := (*string)(latest.ko.Status.ACKResourceMetadata.ARN)
 
-	toAdd, toDelete := computeTagsDelta(
-		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
-	)
+	desiredTags := ToACKTags(desired.ko.Spec.Tags)
+	latestTags := ToACKTags(latest.ko.Spec.Tags)
+
+	added, _, removed := ackcompare.GetTagsDifference(latestTags, desiredTags)
+
+	toAdd := FromACKTags(added)
+	toRemove := FromACKTags(removed)
+
+	var toDelete []*string
+	for _, removedElement := range toRemove {
+		toDelete = append(toDelete, removedElement.Key)
+	}
 
 	if len(toDelete) > 0 {
 		rlog.Debug("removing tags from user", "tags", toDelete)
@@ -141,38 +149,6 @@ func (rm *resourceManager) updateTags(
 	return nil
 }
 
-func computeTagsDelta(
-	desired []*svcapitypes.Tag,
-	latest []*svcapitypes.Tag,
-) (addedOrUpdated []*svcapitypes.Tag, removed []*string) {
-	var visitedIndexes []string
-	var hasSameKey bool
-
-	for _, latestElement := range latest {
-		hasSameKey = false
-		visitedIndexes = append(visitedIndexes, *latestElement.Key)
-		for _, desiredElement := range desired {
-			if equalStrings(latestElement.Key, desiredElement.Key) {
-				hasSameKey = true
-				if !equalStrings(latestElement.Value, desiredElement.Value) {
-					addedOrUpdated = append(addedOrUpdated, desiredElement)
-				}
-				break
-			}
-		}
-		if hasSameKey {
-			continue
-		}
-		removed = append(removed, latestElement.Key)
-	}
-	for _, desiredElement := range desired {
-		if !ackutil.InStrings(*desiredElement.Key, visitedIndexes) {
-			addedOrUpdated = append(addedOrUpdated, desiredElement)
-		}
-	}
-	return addedOrUpdated, removed
-}
-
 func sdkTagsFromResourceTags(
 	rTags []*svcapitypes.Tag,
 ) []*svcsdk.Tag {
@@ -197,13 +173,4 @@ func resourceTagsFromSDKTags(
 		}
 	}
 	return tags
-}
-
-func equalStrings(a, b *string) bool {
-	if a == nil {
-		return b == nil
-	} else if b == nil {
-		return false
-	}
-	return *a == *b
 }


### PR DESCRIPTION
Issue #, if available:
New method of comparing tags was added in runtime. Using this new method to reduce amount of custom logic code of updateTags.

Description of changes:
Use new method in runtime to replace custom logic of comparing two tags.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
