### PR TITLE
Delete `tests/e2e` directory

### DIFF
--- a/tests/e2e/.gitignore
+++ b/tests/e2e/.gitignore
@@ -1,3 +1,0 @@
-__pycache__/
-*.py[cod]
-**/bootstrap.yaml


### PR DESCRIPTION
Description of changes:
The `tests/e2e` directory is an incorrectly named version of the `test/e2e` directory. It should be removed so as to not cause confusion for contributors who might not know where tests should be added.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
