### PR TITLE
Fix incorrect err name

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2023-03-09T05:24:49Z"
+  build_date: "2023-03-13T22:29:26Z"
   build_hash: 910a8e0744a99c5c87d8c1615926985215a60d8c
   go_version: go1.19
   version: v0.24.3

--- a/pkg/resource/acl/sdk.go
+++ b/pkg/resource/acl/sdk.go
@@ -357,9 +357,8 @@ func (rm *resourceManager) sdkUpdate(
 	defer func() {
 		exit(err)
 	}()
-	validationErr := rm.validateACLNeedsUpdate(latest)
-
-	if validationErr != nil {
+	err = rm.validateACLNeedsUpdate(latest)
+	if err != nil {
 		return nil, err
 	}
 

--- a/templates/hooks/acl/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/acl/sdk_update_pre_build_request.go.tpl
@@ -1,6 +1,5 @@
-    validationErr := rm.validateACLNeedsUpdate(latest)
-
-    if validationErr != nil {
+    err = rm.validateACLNeedsUpdate(latest)
+    if err != nil {
 	    return nil, err
     }
 


### PR DESCRIPTION
Issue #, if available:
Controller shuts down if calling `ACL` update while `state` of `ACL` is not `active`.

Description of changes:
One of error name doesn't match its return value. Correct it to match return value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
