### PR TITLE
Return an error message if snapshot is not ready for deleting

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2023-03-16T20:02:03Z"
+  build_date: "2023-03-20T20:22:37Z"
   build_hash: 0888419ec6825035cae1fdee2ceffd7c1ac73ca8
   go_version: go1.19
   version: v0.24.3-5-g0888419

--- a/pkg/resource/snapshot/sdk.go
+++ b/pkg/resource/snapshot/sdk.go
@@ -450,6 +450,11 @@ func (rm *resourceManager) sdkDelete(
 		// TODO: return err as nil when reconciler is updated.
 		return r, requeueWaitWhileDeleting
 	}
+
+	if isNotReadyForDeleting(r) {
+		// return a requeue if snapshot is not ready to be deleted
+		return r, requeueWaitSnapshotIsReadyForDeleting
+	}
 	input, err := rm.newDeleteRequestPayload(r)
 	if err != nil {
 		return nil, err

--- a/templates/hooks/snapshot/sdk_delete_pre_build_request.go.tpl
+++ b/templates/hooks/snapshot/sdk_delete_pre_build_request.go.tpl
@@ -14,3 +14,8 @@
 		// TODO: return err as nil when reconciler is updated.
 		return r, requeueWaitWhileDeleting
 	}
+
+	if isNotReadyForDeleting(r) {
+	    // return a requeue if snapshot is not ready to be deleted
+	    return r, requeueWaitSnapshotIsReadyForDeleting
+	}


### PR DESCRIPTION
Issue #, if available:
If `snapshot` is not ready for deleting and is called by `sdkDelete`, it will have an error `InvalidSnapshotStateFault`.

Description of changes:
Check whether `snapshot` is in the `status` to be deleted. If not, then output an error message.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
