### PR TITLE
tests: Ready condition rename for memorydb-controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -91,3 +91,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/aws-controllers-k8s/runtime => github.com/gustavodiaz7722/ack-runtime v0.54.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/aws-controllers-k8s/ec2-controller v1.0.0 h1:Si71KZjjegndY8ITI732dMPx
 github.com/aws-controllers-k8s/ec2-controller v1.0.0/go.mod h1:/hrKcnF8KpsSoa5vjcVmdaR6OYWPSjkeHdVWwQljRb4=
 github.com/aws-controllers-k8s/kms-controller v1.0.0 h1:Tb1hyedoI+n51gLYmhbYhw9ae1nXQrYzrHhYFCvJSTw=
 github.com/aws-controllers-k8s/kms-controller v1.0.0/go.mod h1:eS2S9pJ6G5f4hvSoEuUyrzUjDkFnE7ctzGv3TUnnTvA=
-github.com/aws-controllers-k8s/runtime v0.52.0 h1:Q5UIAn6SSBr60t/DiU/zr6NLBlUuK2AG3yy2ma/9gDU=
-github.com/aws-controllers-k8s/runtime v0.52.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/aws-controllers-k8s/sns-controller v0.0.5 h1:sFgot4v/LqeO9USfSbaWIQp7DawlF6vhMy1YU2lBXu4=
 github.com/aws-controllers-k8s/sns-controller v0.0.5/go.mod h1:zw3lE2Yie+E6dv3Guaa+tLtH2w5UKoH8IUNCSEJCUoA=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
@@ -90,6 +88,8 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gustavodiaz7722/ack-runtime v0.54.0 h1:Mxf2oUm5Skgf0sLik5otKE5+I2+0ziC1aRWZJOwRiWQ=
+github.com/gustavodiaz7722/ack-runtime v0.54.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/itchyny/gojq v0.12.6 h1:VjaFn59Em2wTxDNGcrRkDK9ZHMNa8IksOgL13sLL4d0=
 github.com/itchyny/gojq v0.12.6/go.mod h1:ZHrkfu7A+RbZLy5J1/JKpS4poEqrzItSTGDItqsfP0A=
 github.com/itchyny/timefmt-go v0.1.3 h1:7M3LGVDsqcd0VZH2U+x393obrzZisp7C0uEe921iRkU=

--- a/test/e2e/declarative_test_fwk/helper.py
+++ b/test/e2e/declarative_test_fwk/helper.py
@@ -182,7 +182,7 @@ class ResourceHelper:
 
             elif type(expected_value) is dict:
                 # Example:
-                # ACK.ResourceSynced:
+                # Ready:
                 #     status: "False"
                 #     message: "Expected message ..."
                 #     timeout: 60 # seconds

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@5a09bbdb961ea14a65b15b63769134125023ac61
+acktest @ git+https://github.com/gustavodiaz7722/ack-test-infra.git@77f6bc5602557fe48e0dd157fefbd97a6aa3e54b

--- a/test/e2e/scenarios/ACL/acl_create_update.yaml
+++ b/test/e2e/scenarios/ACL/acl_create_update.yaml
@@ -22,7 +22,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_k8s:
@@ -48,7 +48,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_k8s:
@@ -71,7 +71,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_k8s:
@@ -101,7 +101,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_k8s:

--- a/test/e2e/scenarios/ACL/acl_terminal_condition.yaml
+++ b/test/e2e/scenarios/ACL/acl_terminal_condition.yaml
@@ -22,7 +22,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_k8s:
@@ -60,7 +60,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_k8s:

--- a/test/e2e/scenarios/ACL/acl_update_with_tags.yaml
+++ b/test/e2e/scenarios/ACL/acl_update_with_tags.yaml
@@ -22,7 +22,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_k8s:
@@ -44,7 +44,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_k8s:
@@ -72,7 +72,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:
@@ -102,7 +102,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:
@@ -128,7 +128,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:

--- a/test/e2e/scenarios/ACL/acl_validate_ref.yaml
+++ b/test/e2e/scenarios/ACL/acl_validate_ref.yaml
@@ -22,7 +22,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
   - id: "USER_TWO_CREATE"
@@ -43,7 +43,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
   - id: "ACL_CREATE_WITH_REF"
@@ -63,7 +63,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
           ACK.ReferencesResolved:

--- a/test/e2e/scenarios/Cluster/cluster_create_update.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_create_update.yaml
@@ -26,7 +26,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 3600
     expect_k8s:
@@ -65,7 +65,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 2800
     expect_k8s:
@@ -95,7 +95,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_k8s:
@@ -117,7 +117,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_k8s:
@@ -140,7 +140,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_k8s:
@@ -171,7 +171,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:
@@ -191,7 +191,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_k8s:
@@ -214,7 +214,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 3600
     expect_k8s:

--- a/test/e2e/scenarios/Cluster/cluster_scale_in_scale_up_increase_replica.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_scale_in_scale_up_increase_replica.yaml
@@ -26,7 +26,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 3600
     expect_k8s:
@@ -53,7 +53,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 3600
     expect_k8s:

--- a/test/e2e/scenarios/Cluster/cluster_scale_out_scale_down_decrease_replica.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_scale_out_scale_down_decrease_replica.yaml
@@ -26,7 +26,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 3600
     expect_k8s:
@@ -53,7 +53,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 4000
     expect_k8s:

--- a/test/e2e/scenarios/Cluster/cluster_terminal_condition.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_terminal_condition.yaml
@@ -35,7 +35,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 3600
     expect_k8s:
@@ -76,7 +76,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 3600
     expect_k8s:

--- a/test/e2e/scenarios/Cluster/cluster_update_with_tags.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_update_with_tags.yaml
@@ -20,7 +20,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 3600
     expect_k8s:
@@ -44,7 +44,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:
@@ -74,7 +74,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:
@@ -100,7 +100,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:

--- a/test/e2e/scenarios/Cluster/cluster_validate_ref.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_validate_ref.yaml
@@ -22,7 +22,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_aws:
@@ -42,7 +42,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_aws:
@@ -61,7 +61,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_aws:
@@ -82,7 +82,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_aws:
@@ -117,7 +117,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 3600
           ACK.ReferencesResolved:

--- a/test/e2e/scenarios/ParameterGroup/pg_update_with_params_and_reset.yaml
+++ b/test/e2e/scenarios/ParameterGroup/pg_update_with_params_and_reset.yaml
@@ -19,7 +19,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:
@@ -120,7 +120,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:
@@ -298,7 +298,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:

--- a/test/e2e/scenarios/ParameterGroup/pg_update_with_tags.yaml
+++ b/test/e2e/scenarios/ParameterGroup/pg_update_with_tags.yaml
@@ -19,7 +19,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:
@@ -39,7 +39,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:
@@ -65,7 +65,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:
@@ -87,7 +87,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:

--- a/test/e2e/scenarios/Snapshot/snapshot_copy.yaml
+++ b/test/e2e/scenarios/Snapshot/snapshot_copy.yaml
@@ -17,7 +17,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 3600
     expect_k8s:
@@ -41,7 +41,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 1800
     expect_k8s:

--- a/test/e2e/scenarios/Snapshot/snapshot_create_update_with_tags.yaml
+++ b/test/e2e/scenarios/Snapshot/snapshot_create_update_with_tags.yaml
@@ -17,7 +17,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 3600
     expect_k8s:
@@ -44,7 +44,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:
@@ -74,7 +74,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:
@@ -100,7 +100,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:

--- a/test/e2e/scenarios/Snapshot/snapshot_create_with_ref.yaml
+++ b/test/e2e/scenarios/Snapshot/snapshot_create_with_ref.yaml
@@ -19,7 +19,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 3600
   - id: "SNAPSHOT_CREATE_WITH_REF"
@@ -37,7 +37,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 1800
           ACK.ReferencesResolved:

--- a/test/e2e/scenarios/SubnetGroup/subnetgroup_create_update.yaml
+++ b/test/e2e/scenarios/SubnetGroup/subnetgroup_create_update.yaml
@@ -20,7 +20,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:
@@ -42,7 +42,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:
@@ -59,7 +59,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:
@@ -83,7 +83,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:

--- a/test/e2e/scenarios/SubnetGroup/subnetgroup_terminal_conditions.yaml
+++ b/test/e2e/scenarios/SubnetGroup/subnetgroup_terminal_conditions.yaml
@@ -32,7 +32,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:

--- a/test/e2e/scenarios/SubnetGroup/subnetgroup_update_with_tags.yaml
+++ b/test/e2e/scenarios/SubnetGroup/subnetgroup_update_with_tags.yaml
@@ -20,7 +20,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:
@@ -40,7 +40,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:
@@ -66,7 +66,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:
@@ -88,7 +88,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:

--- a/test/e2e/scenarios/User/user_create_update.yaml
+++ b/test/e2e/scenarios/User/user_create_update.yaml
@@ -23,7 +23,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:
@@ -46,7 +46,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_k8s:
@@ -69,7 +69,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:
@@ -99,7 +99,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:
@@ -125,7 +125,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:

--- a/test/e2e/scenarios/User/user_terminal_conditions.yaml
+++ b/test/e2e/scenarios/User/user_terminal_conditions.yaml
@@ -34,7 +34,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:

--- a/test/e2e/scenarios/User/user_update_with_tags.yaml
+++ b/test/e2e/scenarios/User/user_update_with_tags.yaml
@@ -23,7 +23,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:
@@ -43,7 +43,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:
@@ -69,7 +69,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:
@@ -91,7 +91,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:


### PR DESCRIPTION
This PR updates test files to the Ready condition:

- Replace `ACK.ResourceSynced` → `Ready`
- Replace `assert_synced` → `assert_ready`
- Replace `assert_not_synced` → `assert_not_ready`

Generated by helper script.