### PR TITLE
tests: Ready condition rename for memorydb-controller

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2025-09-19T17:33:10Z"
-  build_hash: 6b4211163dcc34776b01da9a18217bac0f4103fd
-  go_version: go1.24.6
-  version: v0.52.0
+  build_date: "2025-09-25T05:46:20Z"
+  build_hash: 9c388d9668ea19d0b1b65566d492c4f67c6e64c8
+  go_version: go1.24.7
+  version: 9c388d9
 api_directory_checksum: 0f62053149f9d58731333e46fdbc434a4bf60c15
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/config/crd/bases/memorydb.services.k8s.aws_acls.yaml
+++ b/config/crd/bases/memorydb.services.k8s.aws_acls.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: acls.memorydb.services.k8s.aws
 spec:
   group: memorydb.services.k8s.aws

--- a/config/crd/bases/memorydb.services.k8s.aws_clusters.yaml
+++ b/config/crd/bases/memorydb.services.k8s.aws_clusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: clusters.memorydb.services.k8s.aws
 spec:
   group: memorydb.services.k8s.aws

--- a/config/crd/bases/memorydb.services.k8s.aws_parametergroups.yaml
+++ b/config/crd/bases/memorydb.services.k8s.aws_parametergroups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: parametergroups.memorydb.services.k8s.aws
 spec:
   group: memorydb.services.k8s.aws

--- a/config/crd/bases/memorydb.services.k8s.aws_snapshots.yaml
+++ b/config/crd/bases/memorydb.services.k8s.aws_snapshots.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: snapshots.memorydb.services.k8s.aws
 spec:
   group: memorydb.services.k8s.aws

--- a/config/crd/bases/memorydb.services.k8s.aws_subnetgroups.yaml
+++ b/config/crd/bases/memorydb.services.k8s.aws_subnetgroups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: subnetgroups.memorydb.services.k8s.aws
 spec:
   group: memorydb.services.k8s.aws

--- a/config/crd/bases/memorydb.services.k8s.aws_users.yaml
+++ b/config/crd/bases/memorydb.services.k8s.aws_users.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: users.memorydb.services.k8s.aws
 spec:
   group: memorydb.services.k8s.aws

--- a/go.mod
+++ b/go.mod
@@ -91,3 +91,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/aws-controllers-k8s/runtime => github.com/gustavodiaz7722/ack-runtime v0.57.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/aws-controllers-k8s/ec2-controller v1.0.0 h1:Si71KZjjegndY8ITI732dMPx
 github.com/aws-controllers-k8s/ec2-controller v1.0.0/go.mod h1:/hrKcnF8KpsSoa5vjcVmdaR6OYWPSjkeHdVWwQljRb4=
 github.com/aws-controllers-k8s/kms-controller v1.0.0 h1:Tb1hyedoI+n51gLYmhbYhw9ae1nXQrYzrHhYFCvJSTw=
 github.com/aws-controllers-k8s/kms-controller v1.0.0/go.mod h1:eS2S9pJ6G5f4hvSoEuUyrzUjDkFnE7ctzGv3TUnnTvA=
-github.com/aws-controllers-k8s/runtime v0.52.0 h1:Q5UIAn6SSBr60t/DiU/zr6NLBlUuK2AG3yy2ma/9gDU=
-github.com/aws-controllers-k8s/runtime v0.52.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/aws-controllers-k8s/sns-controller v0.0.5 h1:sFgot4v/LqeO9USfSbaWIQp7DawlF6vhMy1YU2lBXu4=
 github.com/aws-controllers-k8s/sns-controller v0.0.5/go.mod h1:zw3lE2Yie+E6dv3Guaa+tLtH2w5UKoH8IUNCSEJCUoA=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
@@ -90,6 +88,8 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gustavodiaz7722/ack-runtime v0.57.0 h1:85zJyvdPpzOTaWE0icljJcMRf0qlP0oWdOT05hMZ6Z0=
+github.com/gustavodiaz7722/ack-runtime v0.57.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/itchyny/gojq v0.12.6 h1:VjaFn59Em2wTxDNGcrRkDK9ZHMNa8IksOgL13sLL4d0=
 github.com/itchyny/gojq v0.12.6/go.mod h1:ZHrkfu7A+RbZLy5J1/JKpS4poEqrzItSTGDItqsfP0A=
 github.com/itchyny/timefmt-go v0.1.3 h1:7M3LGVDsqcd0VZH2U+x393obrzZisp7C0uEe921iRkU=

--- a/helm/crds/memorydb.services.k8s.aws_acls.yaml
+++ b/helm/crds/memorydb.services.k8s.aws_acls.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: acls.memorydb.services.k8s.aws
 spec:
   group: memorydb.services.k8s.aws

--- a/helm/crds/memorydb.services.k8s.aws_clusters.yaml
+++ b/helm/crds/memorydb.services.k8s.aws_clusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: clusters.memorydb.services.k8s.aws
 spec:
   group: memorydb.services.k8s.aws

--- a/helm/crds/memorydb.services.k8s.aws_parametergroups.yaml
+++ b/helm/crds/memorydb.services.k8s.aws_parametergroups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: parametergroups.memorydb.services.k8s.aws
 spec:
   group: memorydb.services.k8s.aws

--- a/helm/crds/memorydb.services.k8s.aws_snapshots.yaml
+++ b/helm/crds/memorydb.services.k8s.aws_snapshots.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: snapshots.memorydb.services.k8s.aws
 spec:
   group: memorydb.services.k8s.aws

--- a/helm/crds/memorydb.services.k8s.aws_subnetgroups.yaml
+++ b/helm/crds/memorydb.services.k8s.aws_subnetgroups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: subnetgroups.memorydb.services.k8s.aws
 spec:
   group: memorydb.services.k8s.aws

--- a/helm/crds/memorydb.services.k8s.aws_users.yaml
+++ b/helm/crds/memorydb.services.k8s.aws_users.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: users.memorydb.services.k8s.aws
 spec:
   group: memorydb.services.k8s.aws

--- a/helm/crds/services.k8s.aws_adoptedresources.yaml
+++ b/helm/crds/services.k8s.aws_adoptedresources.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: adoptedresources.services.k8s.aws
 spec:
   group: services.k8s.aws

--- a/helm/crds/services.k8s.aws_fieldexports.yaml
+++ b/helm/crds/services.k8s.aws_fieldexports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: fieldexports.services.k8s.aws
 spec:
   group: services.k8s.aws

--- a/pkg/resource/acl/references.go
+++ b/pkg/resource/acl/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -134,8 +135,9 @@ func getReferencedResourceState_User(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"User",
 				namespace, name)
@@ -146,14 +148,14 @@ func getReferencedResourceState_User(
 			"User",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"User",
 			namespace, name)

--- a/pkg/resource/cluster/references.go
+++ b/pkg/resource/cluster/references.go
@@ -25,6 +25,7 @@ import (
 
 	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	snsapitypes "github.com/aws-controllers-k8s/sns-controller/apis/v1alpha1"
@@ -210,8 +211,9 @@ func getReferencedResourceState_ACL(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"ACL",
 				namespace, name)
@@ -222,14 +224,14 @@ func getReferencedResourceState_ACL(
 			"ACL",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"ACL",
 			namespace, name)
@@ -293,8 +295,9 @@ func getReferencedResourceState_ParameterGroup(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"ParameterGroup",
 				namespace, name)
@@ -305,14 +308,14 @@ func getReferencedResourceState_ParameterGroup(
 			"ParameterGroup",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"ParameterGroup",
 			namespace, name)
@@ -376,8 +379,9 @@ func getReferencedResourceState_Topic(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Topic",
 				namespace, name)
@@ -388,14 +392,14 @@ func getReferencedResourceState_Topic(
 			"Topic",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Topic",
 			namespace, name)
@@ -464,8 +468,9 @@ func getReferencedResourceState_SecurityGroup(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"SecurityGroup",
 				namespace, name)
@@ -476,14 +481,14 @@ func getReferencedResourceState_SecurityGroup(
 			"SecurityGroup",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"SecurityGroup",
 			namespace, name)
@@ -547,8 +552,9 @@ func getReferencedResourceState_Snapshot(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Snapshot",
 				namespace, name)
@@ -559,14 +565,14 @@ func getReferencedResourceState_Snapshot(
 			"Snapshot",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Snapshot",
 			namespace, name)
@@ -630,8 +636,9 @@ func getReferencedResourceState_SubnetGroup(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"SubnetGroup",
 				namespace, name)
@@ -642,14 +649,14 @@ func getReferencedResourceState_SubnetGroup(
 			"SubnetGroup",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"SubnetGroup",
 			namespace, name)

--- a/pkg/resource/snapshot/references.go
+++ b/pkg/resource/snapshot/references.go
@@ -25,6 +25,7 @@ import (
 
 	kmsapitypes "github.com/aws-controllers-k8s/kms-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -147,8 +148,9 @@ func getReferencedResourceState_Cluster(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Cluster",
 				namespace, name)
@@ -159,14 +161,14 @@ func getReferencedResourceState_Cluster(
 			"Cluster",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Cluster",
 			namespace, name)
@@ -230,8 +232,9 @@ func getReferencedResourceState_Key(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Key",
 				namespace, name)
@@ -242,14 +245,14 @@ func getReferencedResourceState_Key(
 			"Key",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Key",
 			namespace, name)

--- a/pkg/resource/subnet_group/references.go
+++ b/pkg/resource/subnet_group/references.go
@@ -25,6 +25,7 @@ import (
 
 	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -141,8 +142,9 @@ func getReferencedResourceState_Subnet(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Subnet",
 				namespace, name)
@@ -153,14 +155,14 @@ func getReferencedResourceState_Subnet(
 			"Subnet",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Subnet",
 			namespace, name)

--- a/test/e2e/declarative_test_fwk/helper.py
+++ b/test/e2e/declarative_test_fwk/helper.py
@@ -182,7 +182,7 @@ class ResourceHelper:
 
             elif type(expected_value) is dict:
                 # Example:
-                # ACK.ResourceSynced:
+                # Ready:
                 #     status: "False"
                 #     message: "Expected message ..."
                 #     timeout: 60 # seconds

--- a/test/e2e/declarative_test_fwk/helper.py
+++ b/test/e2e/declarative_test_fwk/helper.py
@@ -194,7 +194,7 @@ class ResourceHelper:
 
                 if wait:
                     assert k8s.wait_on_condition(reference, condition_name, condition_value,
-                                                 wait_periods=wait_timeout, period_length=default_period_length)
+                                                 wait_periods=wait_timeout, period_length=default_period_length, desired_condition_reason=condition_reason)
 
                 k8s_resource_condition = k8s.get_resource_condition(reference,
                                                               condition_name)

--- a/test/e2e/declarative_test_fwk/helper.py
+++ b/test/e2e/declarative_test_fwk/helper.py
@@ -188,6 +188,7 @@ class ResourceHelper:
                 #     timeout: 60 # seconds
                 condition_value = expected_value.get("status")
                 condition_message = expected_value.get("message")
+                condition_reason = expected_value.get("reason")
                 # default wait 60 seconds
                 wait_timeout = expected_value.get("timeout", default_wait_periods)
 
@@ -201,6 +202,8 @@ class ResourceHelper:
                 assert condition_value == k8s_resource_condition.get("status"), f"Condition status mismatch. Expected condition: {condition_name} - {expected_value} but found {k8s_resource_condition}"
                 if condition_message is not None:
                     assert condition_message == k8s_resource_condition.get("message"), f"Condition message mismatch. Expected condition: {condition_name} - {expected_value} but found {k8s_resource_condition}"
+                if condition_reason is not None:
+                    assert condition_reason in k8s_resource_condition.get("reason"), f"Condition reason mismatch. Expected condition: {condition_name} - {expected_value} but found {k8s_resource_condition}"
 
             else:
                 raise Exception(f"Condition {condition_name} is provided with invalid value: {expected_value} ")

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@5a09bbdb961ea14a65b15b63769134125023ac61
+acktest @ git+https://github.com/gustavodiaz7722/ack-test-infra.git@4a5c296da0fe386eadf95c242591ae4724cd0428

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/gustavodiaz7722/ack-test-infra.git@4a5c296da0fe386eadf95c242591ae4724cd0428
+acktest @ git+https://github.com/gustavodiaz7722/ack-test-infra.git@570278a27ff44b4ea2ad566a15244e510a339c10

--- a/test/e2e/scenarios/ACL/acl_create_update.yaml
+++ b/test/e2e/scenarios/ACL/acl_create_update.yaml
@@ -22,7 +22,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_k8s:
@@ -48,7 +48,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_k8s:
@@ -71,7 +71,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_k8s:
@@ -101,7 +101,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_k8s:

--- a/test/e2e/scenarios/ACL/acl_terminal_condition.yaml
+++ b/test/e2e/scenarios/ACL/acl_terminal_condition.yaml
@@ -44,9 +44,10 @@ steps:
     wait:
       status:
         conditions:
-          ACK.Terminal:
-            status: "True"
+          Ready:
+            status: "False"
             timeout: 60
+            reason: "Terminal"
   - id: "UPDATE_ACL_VALID"
     description: "Update userNames"
     patch:
@@ -85,9 +86,10 @@ steps:
     wait:
       status:
         conditions:
-          ACK.Terminal:
-            status: "True"
+          Ready:
+            status: "False"
             timeout: 60
+            reason: "Terminal"
     expect_aws:
       UserNames:
         - user$RANDOM_SUFFIX

--- a/test/e2e/scenarios/ACL/acl_terminal_condition.yaml
+++ b/test/e2e/scenarios/ACL/acl_terminal_condition.yaml
@@ -22,7 +22,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_k8s:
@@ -60,7 +60,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_k8s:

--- a/test/e2e/scenarios/ACL/acl_update_with_tags.yaml
+++ b/test/e2e/scenarios/ACL/acl_update_with_tags.yaml
@@ -22,7 +22,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_k8s:
@@ -44,7 +44,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_k8s:
@@ -72,7 +72,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:
@@ -102,7 +102,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:
@@ -128,7 +128,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:

--- a/test/e2e/scenarios/ACL/acl_validate_ref.yaml
+++ b/test/e2e/scenarios/ACL/acl_validate_ref.yaml
@@ -66,9 +66,6 @@ steps:
           Ready:
             status: "True"
             timeout: 180
-          ACK.ReferencesResolved:
-            status: "True"
-            timeout: 180
     expect_aws:
       UserNames:
         - userone$RANDOM_SUFFIX

--- a/test/e2e/scenarios/ACL/acl_validate_ref.yaml
+++ b/test/e2e/scenarios/ACL/acl_validate_ref.yaml
@@ -22,7 +22,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
   - id: "USER_TWO_CREATE"
@@ -43,7 +43,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
   - id: "ACL_CREATE_WITH_REF"
@@ -63,7 +63,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
           ACK.ReferencesResolved:

--- a/test/e2e/scenarios/Cluster/cluster_create_update.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_create_update.yaml
@@ -26,7 +26,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 3600
     expect_k8s:
@@ -65,7 +65,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 2800
     expect_k8s:
@@ -95,7 +95,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_k8s:
@@ -117,7 +117,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_k8s:
@@ -140,7 +140,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_k8s:
@@ -171,7 +171,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:
@@ -191,7 +191,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_k8s:
@@ -214,7 +214,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 3600
     expect_k8s:

--- a/test/e2e/scenarios/Cluster/cluster_scale_in_scale_up_increase_replica.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_scale_in_scale_up_increase_replica.yaml
@@ -26,7 +26,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 3600
     expect_k8s:
@@ -53,7 +53,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 3600
     expect_k8s:

--- a/test/e2e/scenarios/Cluster/cluster_scale_out_scale_down_decrease_replica.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_scale_out_scale_down_decrease_replica.yaml
@@ -26,7 +26,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 3600
     expect_k8s:
@@ -53,7 +53,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 4000
     expect_k8s:

--- a/test/e2e/scenarios/Cluster/cluster_terminal_condition.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_terminal_condition.yaml
@@ -20,9 +20,10 @@ steps:
     wait:
       status:
         conditions:
-          ACK.Terminal:
-            status: "True"
+          Ready:
+            status: "False"
             timeout: 600
+            reason: "Terminal"
   - id: "FIX_NODE_TYPE"
     description: "Create a Cluster"
     patch:
@@ -58,9 +59,10 @@ steps:
     wait:
       status:
         conditions:
-          ACK.Terminal:
-            status: "True"
+          Ready:
+            status: "False"
             timeout: 1800
+            reason: "Terminal"
     expect_aws:
       NumberOfShards: 2
   - id: "FIX_TERMINAL_CONDITIONS"

--- a/test/e2e/scenarios/Cluster/cluster_terminal_condition.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_terminal_condition.yaml
@@ -35,7 +35,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 3600
     expect_k8s:
@@ -76,7 +76,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 3600
     expect_k8s:

--- a/test/e2e/scenarios/Cluster/cluster_update_with_tags.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_update_with_tags.yaml
@@ -20,7 +20,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 3600
     expect_k8s:
@@ -44,7 +44,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:
@@ -74,7 +74,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:
@@ -100,7 +100,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:

--- a/test/e2e/scenarios/Cluster/cluster_validate_ref.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_validate_ref.yaml
@@ -22,7 +22,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_aws:
@@ -42,7 +42,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_aws:
@@ -61,7 +61,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_aws:
@@ -82,7 +82,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_aws:
@@ -117,7 +117,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 3600
           ACK.ReferencesResolved:

--- a/test/e2e/scenarios/Cluster/cluster_validate_ref.yaml
+++ b/test/e2e/scenarios/Cluster/cluster_validate_ref.yaml
@@ -120,9 +120,6 @@ steps:
           Ready:
             status: "True"
             timeout: 3600
-          ACK.ReferencesResolved:
-            status: "True"
-            timeout: 3600
     expect_aws:
       ACLName: acl$RANDOM_SUFFIX
       ParameterGroupName: pg$RANDOM_SUFFIX

--- a/test/e2e/scenarios/ParameterGroup/pg_create_terminal_condition.yaml
+++ b/test/e2e/scenarios/ParameterGroup/pg_create_terminal_condition.yaml
@@ -19,9 +19,10 @@ steps:
     wait:
       status:
         conditions:
-          ACK.Terminal:
-            status: "True"
+          Ready:
+            status: "False"
             timeout: 60
+            reason: "Terminal"
   - id: "DELETE_PG"
     description: "Delete parameter group"
     delete: pg$RANDOM_SUFFIX

--- a/test/e2e/scenarios/ParameterGroup/pg_update_with_params_and_reset.yaml
+++ b/test/e2e/scenarios/ParameterGroup/pg_update_with_params_and_reset.yaml
@@ -19,7 +19,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:
@@ -120,7 +120,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:
@@ -298,7 +298,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:

--- a/test/e2e/scenarios/ParameterGroup/pg_update_with_tags.yaml
+++ b/test/e2e/scenarios/ParameterGroup/pg_update_with_tags.yaml
@@ -19,7 +19,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:
@@ -39,7 +39,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:
@@ -65,7 +65,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:
@@ -87,7 +87,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:

--- a/test/e2e/scenarios/Snapshot/snapshot_copy.yaml
+++ b/test/e2e/scenarios/Snapshot/snapshot_copy.yaml
@@ -17,7 +17,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 3600
     expect_k8s:
@@ -41,7 +41,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 1800
     expect_k8s:

--- a/test/e2e/scenarios/Snapshot/snapshot_create_update_with_tags.yaml
+++ b/test/e2e/scenarios/Snapshot/snapshot_create_update_with_tags.yaml
@@ -17,7 +17,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 3600
     expect_k8s:
@@ -44,7 +44,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:
@@ -74,7 +74,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:
@@ -100,7 +100,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:

--- a/test/e2e/scenarios/Snapshot/snapshot_create_with_ref.yaml
+++ b/test/e2e/scenarios/Snapshot/snapshot_create_with_ref.yaml
@@ -19,7 +19,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 3600
   - id: "SNAPSHOT_CREATE_WITH_REF"
@@ -37,7 +37,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 1800
           ACK.ReferencesResolved:

--- a/test/e2e/scenarios/Snapshot/snapshot_create_with_ref.yaml
+++ b/test/e2e/scenarios/Snapshot/snapshot_create_with_ref.yaml
@@ -40,9 +40,6 @@ steps:
           Ready:
             status: "True"
             timeout: 1800
-          ACK.ReferencesResolved:
-            status: "True"
-            timeout: 1800
     expect_aws:
       ClusterConfiguration:
         Name: cluster$RANDOM_SUFFIX

--- a/test/e2e/scenarios/SubnetGroup/subnetgroup_create_update.yaml
+++ b/test/e2e/scenarios/SubnetGroup/subnetgroup_create_update.yaml
@@ -20,7 +20,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:
@@ -42,7 +42,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:
@@ -59,7 +59,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:
@@ -83,7 +83,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:

--- a/test/e2e/scenarios/SubnetGroup/subnetgroup_terminal_conditions.yaml
+++ b/test/e2e/scenarios/SubnetGroup/subnetgroup_terminal_conditions.yaml
@@ -32,7 +32,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:

--- a/test/e2e/scenarios/SubnetGroup/subnetgroup_terminal_conditions.yaml
+++ b/test/e2e/scenarios/SubnetGroup/subnetgroup_terminal_conditions.yaml
@@ -20,9 +20,10 @@ steps:
     wait:
       status:
         conditions:
-          ACK.Terminal:
-            status: "True"
+          Ready:
+            status: "False"
             timeout: 60
+            reason: "Terminal"
   - id: "UPDATE_SUBNET_VALID"
     description: "Update SubnetGroup SubnetIds"
     patch:
@@ -53,9 +54,10 @@ steps:
     wait:
       status:
         conditions:
-          ACK.Terminal:
-            status: "True"
+          Ready:
+            status: "False"
             timeout: 60
+            reason: "Terminal"
     expect_aws:
       Subnets:
         - Identifier: $SUBNET1

--- a/test/e2e/scenarios/SubnetGroup/subnetgroup_update_with_tags.yaml
+++ b/test/e2e/scenarios/SubnetGroup/subnetgroup_update_with_tags.yaml
@@ -20,7 +20,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:
@@ -40,7 +40,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:
@@ -66,7 +66,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:
@@ -88,7 +88,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:

--- a/test/e2e/scenarios/User/user_create_update.yaml
+++ b/test/e2e/scenarios/User/user_create_update.yaml
@@ -23,7 +23,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:
@@ -46,7 +46,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 180
     expect_k8s:
@@ -69,7 +69,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:
@@ -99,7 +99,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:
@@ -125,7 +125,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:

--- a/test/e2e/scenarios/User/user_terminal_conditions.yaml
+++ b/test/e2e/scenarios/User/user_terminal_conditions.yaml
@@ -34,7 +34,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:

--- a/test/e2e/scenarios/User/user_terminal_conditions.yaml
+++ b/test/e2e/scenarios/User/user_terminal_conditions.yaml
@@ -23,9 +23,10 @@ steps:
     wait:
       status:
         conditions:
-          ACK.Terminal:
-            status: "True"
+          Ready:
+            status: "False"
             timeout: 60
+            reason: "Terminal"
   - id: "USER_UPDATE_ACCESS_STRING"
     description: "Update AccessString"
     patch:
@@ -52,9 +53,10 @@ steps:
     wait:
       status:
         conditions:
-          ACK.Terminal:
-            status: "True"
+          Ready:
+            status: "False"
             timeout: 60
+            reason: "Terminal"
     expect_aws:
       AccessString: off resetchannels -@all +get
   - id: "DELETE_USER"

--- a/test/e2e/scenarios/User/user_update_with_tags.yaml
+++ b/test/e2e/scenarios/User/user_update_with_tags.yaml
@@ -23,7 +23,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 100
     expect_k8s:
@@ -43,7 +43,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:
@@ -69,7 +69,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:
@@ -91,7 +91,7 @@ steps:
     wait:
       status:
         conditions:
-          ACK.ResourceSynced:
+          Ready:
             status: "True"
             timeout: 10
     expect_k8s:


### PR DESCRIPTION
This PR updates controller src and test files to the Ready condition:

- Run code generation 
- Update test infra commit id 
- Replace `ACK.ResourceSynced` → `Ready`
- Replace `assert_synced` → `assert_ready`
- Replace `assert_not_synced` → `assert_not_ready`

Generated by helper script.

_No manual changes were made to the controller source; all changes were made via automated script._